### PR TITLE
Ensure loaders all convert data to nm.

### DIFF
--- a/src/playNano/io/formats/read_asd.py
+++ b/src/playNano/io/formats/read_asd.py
@@ -2,6 +2,7 @@
 Module to decode and load .asd high speed AFM data files into Python NumPy arrays.
 
 Files containing multiple image frames are read together.
+Converts the height data into SI units (m) typically from nm.
 """
 
 import logging
@@ -11,13 +12,43 @@ import numpy as np
 from AFMReader.asd import load_asd
 
 from playNano.afm_stack import AFMImageStack
+from playNano.utils.io_utils import convert_height_units_to_nm, guess_height_data_units
 
 logger = logging.getLogger(__name__)
 
 
+def _standardize_units_to_nm(image_stack: np.ndarray, channel: str) -> np.ndarray:
+    """
+    Convert height data to nanometers if the channel is topography ("TP").
+
+    Attempts to guess the unit from data range; defaults to 'nm' on failure.
+
+    Parameters
+    ----------
+    image_stack : np.ndarray
+        AFM height data array (2D or 3D).
+    channel : str
+        Channel name; must be "TP" to trigger conversion.
+
+    Returns
+    -------
+    None
+    """
+    try:
+        height_unit = guess_height_data_units(image_stack)
+        logger.info(f"Guessed that the height unit is {height_unit}")
+    except Exception as e:
+        height_unit = "nm"
+        logger.warning(f"Failed to guess height unit, defaulting to 'nm': {e}")
+
+    if channel == "TP":
+        image_stack[:] = convert_height_units_to_nm(image_stack, height_unit)
+    return image_stack
+
+
 def load_asd_file(file_path: Path | str, channel: str) -> AFMImageStack:
     """
-    Load image stack from an .asd file.
+    Load image stack from an .asd file scaled to nanometers.
 
     Parameters
     ----------
@@ -35,6 +66,8 @@ def load_asd_file(file_path: Path | str, channel: str) -> AFMImageStack:
 
     # Read .asd data and header
     image_stack, pixel_size_nm, asd_metadata = load_asd(file_path, channel)
+
+    image_stack = _standardize_units_to_nm(image_stack, channel)
 
     frame_time = asd_metadata["frame_time"]
     lines = asd_metadata["y_pixels"]

--- a/src/playNano/io/formats/read_h5jpk.py
+++ b/src/playNano/io/formats/read_h5jpk.py
@@ -11,6 +11,11 @@ import h5py
 import numpy as np
 
 from playNano.afm_stack import AFMImageStack
+from playNano.utils.io_utils import (
+    convert_height_units_to_nm,
+    guess_height_data_units,
+    height_units,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +154,33 @@ def _get_z_scaling_h5(channel_group: h5py.Group) -> tuple[float, float]:
     return multiplier, offset
 
 
+def _get_z_unit_h5(channel_group: h5py.Group) -> str:
+    """
+    Extract the Z unit from an HDF5 channel group.
+
+    Parameters
+    ----------
+    channel_group : h5py.Group
+        The HDF5 group corresponding to a specific channel
+        (e.g. /Measurement_000/Channel_001).
+
+    Returns
+    -------
+    string
+        The unit of the z data values.
+
+    Notes
+    -----
+    Defaults to None if attribute is not present.
+    """
+    try:
+        z_unit = str(channel_group.attrs.get("net-encoder.scaling.unit.unit", 1.0))
+    except Exception as e:
+        z_unit = None
+        logger.warning(f"Failed to read unit, returning None: {e}")
+    return z_unit
+
+
 def _get_image_shape(measurement_group: h5py.Group) -> float:
     """
     Extract pixel width and hight from an HDF5 JPK measurement group.
@@ -266,11 +298,56 @@ def _get_line_rate(measurement_group: h5py.Group) -> float:
         ) from e
 
 
+def _guess_and_standardize_units_to_nm(image_stack: np.ndarray) -> np.ndarray:
+    """
+    Convert height data to nanometers for metric data.
+
+    Attempts to guess the unit from data range; defaults to 'nm' on failure.
+
+    Parameters
+    ----------
+    image_stack : np.ndarray
+        AFM height data array (2D or 3D).
+
+    Returns
+    -------
+    None
+    """
+    try:
+        height_unit = guess_height_data_units(image_stack)
+        logger.info(f"Guessed that the height unit is {height_unit}")
+    except Exception as e:
+        height_unit = "nm"
+        logger.warning(f"Failed to guess height unit, defaulting to 'nm': {e}")
+    image_stack[:] = convert_height_units_to_nm(image_stack, height_unit)
+    return image_stack
+
+
+def apply_z_unit_conversion(
+    images: np.ndarray, channel_group: h5py.Group, channel: str = "TP"
+) -> np.ndarray:
+    """Apply z unit conversion to nanometers if needed, or guess if unknown."""
+    try:
+        z_unit = _get_z_unit_h5(channel_group)
+    except Exception as e:
+        logging.warning(f"Could not read unit for channel '{channel}': {e}")
+        z_unit = None
+
+    if z_unit is not None and z_unit in height_units:
+        images = convert_height_units_to_nm(images, z_unit)
+    elif z_unit is not None and z_unit in ["V", "v", "deg"]:
+        pass  # No conversion needed
+    else:
+        images = _guess_and_standardize_units_to_nm(images)
+
+    return images
+
+
 def load_h5jpk(
     file_path: Path | str, channel: str, flip_image: bool = True
 ) -> AFMImageStack:
     """
-    Load image stack from a JPK .h5-jpk file.
+    Load image stack from a JPK .h5-jpk file, scaled to nanometers.
 
     The images are loaded, reshaped into frames, and have timestamps generated.
 
@@ -299,6 +376,9 @@ def load_h5jpk(
         # Apply Z scaling and offset
         scaling, offset = _get_z_scaling_h5(channel_group)
         images = (raw_images * scaling) + offset
+
+        # Convert to nm if necessary
+        images = apply_z_unit_conversion(images, channel_group, channel)
 
         # Get image shape and number of frames
         height_px, width_px = _get_image_shape(measurement_group)

--- a/src/playNano/io/formats/read_jpk_folder.py
+++ b/src/playNano/io/formats/read_jpk_folder.py
@@ -42,6 +42,8 @@ def load_jpk_folder(
     """
     Load an AFM video from a folder of individual .jpk image files.
 
+    AFMReader converts "height", "measuredHeight" and "amplitude" channels to nm.
+
     Parameters
     ----------
     folder_path : Path | str
@@ -79,7 +81,6 @@ def load_jpk_folder(
     image_stack = np.empty((num_frames, height_px, width_px), dtype=dtype)
 
     # Extract metadata from first image
-
     # Line rate and timestamps
     line_rate = _extract_scan_rate(jpk_files[0])  # lines per second
     lines_per_frame = height_px  # number of fast scan lines in an image

--- a/src/playNano/io/loader.py
+++ b/src/playNano/io/loader.py
@@ -100,6 +100,8 @@ def load_afm_stack(file_path: Path, channel: str = "height_trace") -> AFMImageSt
     This loader splits these two approaches and loads both into
     the common AFMImageStack object for processing.
 
+    All data values with length units (i.e. m) are converted to nm.
+
     Parameters
     ----------
     file_path : Path | str

--- a/src/playNano/utils/io_utils.py
+++ b/src/playNano/utils/io_utils.py
@@ -8,6 +8,8 @@ import numpy as np
 INVALID_CHARS = r'\/:*?"<>|'
 INVALID_FOLDER_CHARS = r'*?"<>|'
 
+height_units = ["m", "cm", "mm", "um", "nm", "pm"]
+
 
 def pad_to_square(img: np.ndarray, border_color: int = 0) -> np.ndarray:
     """Pad a 2D grayscale image to a square canvas by centring it."""
@@ -18,6 +20,99 @@ def pad_to_square(img: np.ndarray, border_color: int = 0) -> np.ndarray:
     x = (size - w) // 2
     canvas[y : y + h, x : x + w] = img  # noqa
     return canvas
+
+
+def guess_height_data_units(stack: np.ndarray) -> str:
+    """
+    Guess the most likely units of AFM height data from the data range.
+
+    Parameters
+    ----------
+    stack : np.ndarray
+        AFM height data array, typically 2D or 3D. Non-finite values
+        (NaN or infinity) are ignored when determining the range.
+
+    Returns
+    -------
+    str
+        A string indicating the guessed unit of the height data, one of:
+        'pm' (picometers), 'nm' (nanometers), 'um' (micrometers),
+        'mm' (millimeters), or 'm' (meters).
+
+    Raises
+    ------
+    ValueError
+        If the input array contains no finite values.
+
+    Notes
+    -----
+    The unit is estimated based on the numeric range of the data as follows:
+        - Range > 1e4           : 'pm'
+        - 1e-2 < Range <= 1e4   : 'nm'
+        - 1e-4 < Range <= 1e-2  : 'um'
+        - 1e-5 < Range <= 1e-4  : 'mm'
+        - Range <= 1e-5         : 'm'
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> data = np.array([[0, 5e-9], [1e-8, 2e-8]])
+    >>> guess_height_data_units(data)
+    'nm'
+    """
+    finite = stack[np.isfinite(stack)]
+    if finite.size == 0:
+        raise ValueError("No finite values in data.")
+
+    z_range = finite.max() - finite.min()
+    if z_range > 1e4:
+        return "pm"
+    elif 1e-2 < z_range <= 1e4:
+        return "nm"
+    elif 1e-4 < z_range <= 1e-2:
+        return "um"
+    elif 1e-5 < z_range <= 1e-4:
+        return "mm"
+    else:
+        return "m"
+
+
+def convert_height_units_to_nm(data: np.ndarray, unit: str) -> np.ndarray:
+    """
+    Convert AFM height data from the guessed unit to nanometers.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Input height data array, typically 2D or 3D.
+    unit : str
+        Unit string as returned by `guess_height_data_units`. Must be one of:
+        'pm', 'nm', 'um', 'mm', or 'm'.
+
+    Returns
+    -------
+    np.ndarray
+        The input data converted to nanometers.
+
+    Raises
+    ------
+    ValueError
+        If the provided unit string is not recognized.
+    """
+    unit_to_multiplier = {
+        "pm": 1e-3,  # 1 pm = 1e-3 nm
+        "nm": 1.0,  # already in nm
+        "um": 1e3,  # 1 µm = 1000 nm
+        "mm": 1e6,  # 1 mm = 1e6 nm
+        "m": 1e9,  # 1 m = 1e9 nm
+    }
+
+    if unit not in unit_to_multiplier:
+        raise ValueError(
+            f"Unrecognized unit '{unit}'. Must be one of: {list(unit_to_multiplier)}"
+        )
+
+    return data * unit_to_multiplier[unit]
 
 
 def normalize_to_uint8(image: np.ndarray) -> np.ndarray:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,15 @@
 """Tests for the utility functions."""
 
+import unittest
+
 import numpy as np
 
-from playNano.utils.io_utils import normalize_to_uint8, pad_to_square
+from playNano.utils.io_utils import (
+    convert_height_units_to_nm,
+    guess_height_data_units,
+    normalize_to_uint8,
+    pad_to_square,
+)
 
 
 def test_pad_to_square():
@@ -21,3 +28,56 @@ def test_normalize_to_uint8():
     assert norm_img.dtype == np.uint8
     assert norm_img.min() == 0
     assert norm_img.max() == 255
+
+
+class TestGuessHeightDataUnits(unittest.TestCase):
+    """Tests for the guess_height_data_units function."""
+
+    def test_picometers(self):
+        """Detects picometer scale data range."""
+        data = np.array([0, 2e5])  # range 2e5 > 1e4 → 'pm'
+        self.assertEqual(guess_height_data_units(data), "pm")
+
+    def test_nanometers(self):
+        """Detects nanometer scale data range."""
+        data = np.array([0, 5e-2])  # 1e-2 < 5e-2 <= 1e4 → 'nm'
+        self.assertEqual(guess_height_data_units(data), "nm")
+
+    def test_micrometers(self):
+        """Detects micrometer scale data range."""
+        data = np.array([0, 5e-3])  # 1e-4 < 5e-3 <= 1e-2 → 'um'
+        self.assertEqual(guess_height_data_units(data), "um")
+
+    def test_millimeters(self):
+        """Detects millimeter scale data range."""
+        data = np.array([0, 5e-5])  # 1e-5 < 5e-5 <= 1e-4 → 'mm'
+        self.assertEqual(guess_height_data_units(data), "mm")
+
+    def test_meters(self):
+        """Detects meter scale data range."""
+        data = np.array([0, 5e-6])  # <= 1e-5 → 'm'
+        self.assertEqual(guess_height_data_units(data), "m")
+
+    def test_zero_range(self):
+        """Handles zero range data by falling back to 'm'."""
+        data = np.full((10,), 42)  # all constant values → 'm' fallback
+        self.assertEqual(guess_height_data_units(data), "m")
+
+    def test_non_finite_values(self):
+        """Ignores non-finite values when guessing units."""
+        data = np.array([np.nan, np.inf, -np.inf, 10, 20])
+        self.assertEqual(guess_height_data_units(data), "nm")  # range = 10
+
+    def test_no_finite_raises(self):
+        """Raises ValueError if no finite data values exist."""
+        data = np.array([np.nan, np.inf, -np.inf])
+        with self.assertRaises(ValueError):
+            guess_height_data_units(data)
+
+
+def test_convert_height_units_to_nm():
+    """Test conversion of height units to nanometers."""
+    data = np.array([[1e3, 2e3]])  # pretend this is in meters
+    expected = np.array([[1e6, 2e6]])  # nanometers
+    result = convert_height_units_to_nm(data, "m")
+    np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
In order to have all data at the same scale once loaded into the AFMImageStack class I updated the loaders to ensure the height data was in nm. 