### PR TITLE
Pin Sphinx to version <9 for compatibility with sphinx-multiversion.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dev = [
 ]
 
 docs = [
-    "sphinx",
+    "sphinx<9",
     "furo",
     "myst-parser",
     "sphinx-autoapi",


### PR DESCRIPTION
Hit a incompatibility between sphinx‑multiversion and newer Sphinx. 

Error in CI doc deployment:
TypeError: Config.read() takes 2 positional arguments but 3 were given

This happens when sphinx-multiversion calls into Sphinx with an older Config.read() signature. Recent Sphinx releases changed that API, so SMV breaks. 

This pins sphinx to <9 to prevent this error. 