### PR TITLE
Allow variable pixel scaling factors and add ARIS reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added built-in processing filter, `vertical_flip`, which uses the NumPy `flipud()` function to reverse the row
     order of a 2D image. No eqivielent masked filter.
 
+- **ARIS Reader**
+  - Support for loading Asylum Research **`.aris`** high‑speed AFM data files.
+  - Comprehensive ARIS file loader including:
+    - Channel-name extraction from HDF5 metadata.
+    - Global and per‑frame pixel-size scaling with correct fallback behaviour.
+    - Frame sorting and stacked‑image construction.
+    - Timestamp parsing and validation.
+
+  - Multi‑suffix file loading support, enabling correct detection of formats such as
+    `.ome.tif` alongside standard single‑suffix extensions.
+
+  - **Tests** including:
+    - Synthetic ARIS HDF5 generator.
+    - Tests for multi-suffix handling (`.ome.tif` / `.tif`).
+    - Tests for per-frame scaling overrides and global-scaling fallback.
+    - Tests for timestamp mismatch, missing channels, and invalid files.
+
+### Changed
+
+- **Pixel size scaling**
+  - `pixel_size_nm` handling updated:
+    - AFMImageStack attribute `pixel_size_nm` retained and specified as a global
+      or first frame value.
+    - Per-frame overrides stored in `frame_metadata["frame_pixel_size_nm"]`.
+    - For most loaded data these values will all be the same unless the physical
+      scan size changes mid scan (i.e. in an ARIS file.)
+    - GUI and gif_export updated to use these per-frame values.
+    - Documentation updated in NPZ, OME-TIFF, and HDF5 export sections to reflect
+      per-frame pixel-size support.
+
+### Fixed
+
+- Resolved missing-extension and no-suffix errors in loader logic.
+
 ## [0.3.1] - 2026-03-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Learn more about the motivation, design, and structure of playNano in the [Intro
 **Files read:**
 <div align="center">
 
-**`.h5-jpk`, `.jpk`, `.asd`, `.spm`**
+**`.h5-jpk`, `.jpk`, `.asd`, `.spm`, `.aris`**
 
 </div>
 
@@ -54,7 +54,7 @@ Full documentation: <https://derollins.github.io/playNano/>
 
 ## ✨ Features
 
-- 📂 **AFM time-series extraction** — reads `.h5-jpk`, `.asd`, and folders of `.jpk` or `.spm` frames.
+- 📂 **AFM time-series extraction** — reads `.h5-jpk`, `.asd`, `.aris`, and folders of `.jpk` or `.spm` frames.
 - ▶️ **Interactive video viewer** — PySide6-based GUI with playback, z-scale control, and export tools.
 - 🪟 **Processing pipeline** — applies filters and masks with full provenance tracking.
 - 📏 **Analysis pipeline** — runs detection, clustering, and tracking with reproducible outputs.

--- a/docs/exporting.rst
+++ b/docs/exporting.rst
@@ -105,6 +105,13 @@ The OME-TIFF export stores the processed AFM video from the
 of frames in a format compatible with ImageJ, Fiji, Bio-Formats, and general
 image analysis tools.
 
+.. note::
+
+   Since the OME-TIFF metadata schema only contains a
+   single value for `PhysicalSizeX`, `PhysicalSizeY` for all images in a stack,
+   all frames in a stack must have the same `frame_pixel_size_nm` value in the
+   `frame_metadata` dictionaries.
+
 **Contents**
 
 - Each frame stored as a TIFF plane
@@ -150,7 +157,7 @@ NPZ Export
 - ``data`` - raw or processed image stack
 - ``processed__<step>`` - processed frame arrays
 - ``masks__<mask>`` - Boolean mask arrays
-- ``frame_metadata_json`` - per-frame metadata including timestamps
+- ``frame_metadata_json`` - per-frame metadata including timestamps and per frame pixel sizes in nanometres
 - ``provenance_json`` - full processing and analysis history
 - ``pixel_size_nm`` - pixel size in nanometres
 - ``channel`` - data channel name
@@ -201,12 +208,12 @@ HDF5 Export
 - ``/data`` - raw or processed image stack
 - ``/processed/<step>`` - filtered or analysis layers
 - ``/masks/<mask>`` - Boolean masks
-- ``/frame_metadata_json`` - per-frame metadata including timestamps
+- ``/frame_metadata_json`` - per-frame metadata including timestamps and per frame pixel sizes in nanometres
 - ``/provenance_json`` - full processing and analysis history
 
 **Attributes**
 
-- ``pixel_size_nm`` - pixel size in nanometres
+- ``pixel_size_nm`` - pixel size in nanometres for the first frame (usually same for all frames)
 - ``channel`` - channel name
 
 **Example structure**
@@ -257,7 +264,7 @@ stack, with optional annotations.
 **Annotations**
 
 - **Timestamps** - derived from frame metadata
-- **Scale bar** - physical calibration (default 100 nm)
+- **Scale bar** - physical calibration (default 100 nm) determined from the per frame pixel size metadata
 - **Colour map** - default ``afmhot`` normalisation
 - **Frame rate** - determined from timing metadata
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -35,7 +35,8 @@ Core Components
 1. **Loading** - Imports a sequence of AFM frames into an
    :class:`~playnano.afm_stack.AFMImageStack`, preserving timestamps and metadata.
    The following AFM file formats are supported:
-   ``.jpk``, ``.asd``, ``.h5-jpk``, and ``.spm``.
+   ``.jpk``, ``.asd``, ``.aris``, ``.h5-jpk``, and ``.spm``.
+   Additionally files exported from playNano can be re-loaded back into the programme.
 2. **Processing** - Applies flattening, filtering, and frame-alignment operations
    to prepare data for analysis and export. Pipelines are defined as ordered
    lists of steps that run serially on the stack. See more: :doc:`processing`.

--- a/src/playnano/afm_stack.py
+++ b/src/playnano/afm_stack.py
@@ -45,7 +45,7 @@ class AFMImageStack:
         data.
 
     pixel_size_nm : float
-        Physical pixel size in nanometers.
+        Physical pixel size in nanometers of the first frame (fallback).
 
     channel : str
         Channel name.
@@ -54,7 +54,8 @@ class AFMImageStack:
         Path to the source file or folder.
 
     frame_metadata : list[dict[str, Any]]
-        Per-frame metadata dicts; each will include a normalized 'timestamp' key.
+        Per-frame metadata dicts; each will include a normalized 'timestamp' key and
+        per frame 'frame_pixel_size_nm'.
 
     processed : dict[str, np.ndarray]
         Snapshots of processed data arrays from filters. Keys like
@@ -95,7 +96,7 @@ class AFMImageStack:
             stack.
 
         pixel_size_nm : float
-            Pixel size in nanometers; must be positive.
+            Pixel size in nanometers for the first frame; must be positive.
 
         channel : str
             Channel name (e.g., 'height_trace').

--- a/src/playnano/afm_stack.py
+++ b/src/playnano/afm_stack.py
@@ -107,7 +107,9 @@ class AFMImageStack:
         frame_metadata : list of dict, optional
             List of per-frame metadata dicts. Will be padded or trimmed to length
             n_frames. After initialization, each entry is normalized to include a
-            numeric 'timestamp' (fallback to frame index if missing).
+            numeric 'timestamp' (fallback to frame index if missing). A pixel scaling
+            value for each frame `frame_pixel_size_nm` is also recorded when data is
+            loaded from a raw or processed file.
 
         Raises
         ------

--- a/src/playnano/afm_stack.py
+++ b/src/playnano/afm_stack.py
@@ -931,6 +931,49 @@ class AFMImageStack:
         ts = self.frame_metadata[idx].get("timestamp", None)
         return float(idx) if ts is None else ts
 
+    def scaling_for_frame(self, idx: int) -> float:
+        """
+        Get the frame_pixel_size_nm for a given frame index.
+
+        If the frame_metadata dictionaries or frame_pixel_size_nm values are missing
+        fallback to the pixel_size_nm attribute.
+
+        Parameters
+        ----------
+        idx : int
+            Frame index.
+
+        Returns
+        -------
+        float
+            Pixel to nanometer scaling factor.
+
+        Raises
+        ------
+        IndexError
+            If idx is out of range.
+
+        Notes
+        -----
+        The fallback to pixel_size_nm is valid for stacks with a constant size.
+
+        Examples
+        --------
+        >>> stack.pixel_size_nm = 1.0   # fallback value
+        >>> stack.frame_metadata = [
+        ...     {"frame_pixel_size_nm": 1.0},
+        ...     {},
+        ...     {"frame_pixel_size_nm": 2.0},
+        ... ]
+        >>> stack.scaling_for_frame(0)
+        1.0
+        >>> stack.scaling_for_frame(1)
+        1.0          # falls back to stack.pixel_size_nm
+        >>> stack.scaling_for_frame(2)
+        2.0
+        """
+        return self.frame_metadata[idx].get("frame_pixel_size_nm", self.pixel_size_nm)
+
     def get_frame_times(self) -> list[float]:
         """
         Return a list of timestamps (in seconds) for each frame in the stack.

--- a/src/playnano/cli/actions.py
+++ b/src/playnano/cli/actions.py
@@ -279,12 +279,13 @@ def play_pipeline_mode(
     -------
     None
     """
+
     try:
         afm_stack = AFMImageStack.load_data(input_file, channel=channel)
-    except LoadError as e:
-        logger.exception(
-            f"Failed to load {input_file}, error: {e}"
-        )  # exception() includes traceback
+    except Exception as e:
+        logger.error(f"Failed to load {input_file}. {e}")
+        raise LoadError(f"Failed to load {input_file}: {e}") from e
+
     # Determine fps from metadata
     frame_metadata = getattr(afm_stack, "frame_metadata", None)
     line_rate = None

--- a/src/playnano/cli/actions.py
+++ b/src/playnano/cli/actions.py
@@ -281,8 +281,10 @@ def play_pipeline_mode(
     """
     try:
         afm_stack = AFMImageStack.load_data(input_file, channel=channel)
-    except Exception as e:
-        raise LoadError(f"Failed to load {input_file}") from e
+    except LoadError as e:
+        logger.exception(
+            f"Failed to load {input_file}, error: {e}"
+        )  # exception() includes traceback
     # Determine fps from metadata
     frame_metadata = getattr(afm_stack, "frame_metadata", None)
     line_rate = None

--- a/src/playnano/gui/window.py
+++ b/src/playnano/gui/window.py
@@ -563,8 +563,10 @@ class MainWindow(QMainWindow):
 
         # Read timestamp
         timestamp = self.afm_stack.time_for_frame(idx)
-
-        pixel_size_nm = self.afm_stack.pixel_size_nm
+        try:
+            pixel_size_nm = self.afm_stack.frame_metadata[idx]["frame_pixel_size_nm"]
+        except ValueError:
+            pixel_size_nm = self.afm_stack.pixel_size_nm
         if not isinstance(pixel_size_nm, (float, int)) or pixel_size_nm <= 0:
             pixel_size_nm = 1.0  # fallback or disable scale bar
 
@@ -575,7 +577,7 @@ class MainWindow(QMainWindow):
                 draw_ts=self.show_timestamp_box.isChecked(),
                 draw_scale=self.show_scale_bar_box.isChecked(),
                 draw_raw_label=not self._show_flat,
-                pixel_size_nm=self.afm_stack.pixel_size_nm,
+                pixel_size_nm=pixel_size_nm,
                 scale_bar_nm=self.scale_bar_nm,
             )
         except Exception as e:

--- a/src/playnano/gui/window.py
+++ b/src/playnano/gui/window.py
@@ -563,10 +563,8 @@ class MainWindow(QMainWindow):
 
         # Read timestamp
         timestamp = self.afm_stack.time_for_frame(idx)
-        try:
-            pixel_size_nm = self.afm_stack.frame_metadata[idx]["frame_pixel_size_nm"]
-        except ValueError:
-            pixel_size_nm = self.afm_stack.pixel_size_nm
+        pixel_size_nm = self.afm_stack.scaling_for_frame(idx)
+
         if not isinstance(pixel_size_nm, (float, int)) or pixel_size_nm <= 0:
             pixel_size_nm = 1.0  # fallback or disable scale bar
 

--- a/src/playnano/io/data_loaders.py
+++ b/src/playnano/io/data_loaders.py
@@ -317,6 +317,8 @@ def load_ome_tiff_stack(path: Path, channel: str = "height_trace") -> AFMImageSt
             logger.warning(f"Failed to parse OME-XML metadata for {path}: {e}")
 
         frame_metadata = [{"timestamp": t} for t in timestamps]
+        for frame in frame_metadata:
+            frame["frame_pixel_size_nm"] = ps_nm
 
         stack = AFMImageStack(
             data=data,

--- a/src/playnano/io/data_loaders.py
+++ b/src/playnano/io/data_loaders.py
@@ -4,7 +4,8 @@ Data loaders for AFM image stacks exported by **playNano**.
 This module provides readers for serialized AFMImageStack bundles created
 by the export routines (``.npz``, ``.h5``, and OME-TIFF). Each loader
 reconstructs a :class:`~playNano.afm_stack.AFMImageStack` with correct
-data, pixel size, channel name, and per-frame metadata (timestamps).
+data, pixel size, channel name, and per-frame metadata (timestamps,
+frame_pixel_size_nm etc.)
 All loaders restore provenance and any stored processing or mask data.
 
 Functions

--- a/src/playnano/io/export_data.py
+++ b/src/playnano/io/export_data.py
@@ -146,6 +146,13 @@ def save_ome_tiff_stack(
     channel = afm_stack.channel
     planes = [{"DeltaT": float(t)} for t in timestamps]
 
+    pixel_sizes = [md["frame_pixel_size_nm"] for md in meta_src]
+    if not np.allclose(afm_stack.pixel_size_nm, pixel_sizes):
+        raise ValueError(
+            f"pixel_size_nm is not consistent across frames "
+            f"(min={min(pixel_sizes):.4f}, max={max(pixel_sizes):.4f} nm)."
+        )
+
     ome_metadata = {
         "axes": "TCZYX",
         "PhysicalSizeX": afm_stack.pixel_size_nm * 1e-3,

--- a/src/playnano/io/formats/read_aris.py
+++ b/src/playnano/io/formats/read_aris.py
@@ -1,11 +1,10 @@
 """
-Module to decode and load .aris high speed AFM data files into a AFMImageStack object.
+Module to decode and load .aris high-speed AFM data files into an AFMImageStack object.
 
-Files containing multiple image frames are read together. Since the frames in .aris
-files can be different sizes the pixel scaling value for the first frame is held as
-an AFMImageStack object (pixel_size_nm) while the values for indevidual frames are
-stored per frame in the frame_metadat list of dictionaries under the key,
-``frame_pixel_size_nm``.
+The Asylum Reseach ARIS files contain multiple frames that may differ in pixel
+resolution. The global pixel size (from the first frame) is stored in
+`pixel_size_nm`, while per-frame overrides are stored in each entry of
+`frame_metadata` under the key `frame_pixel_size_nm`.
 """
 
 import logging
@@ -22,27 +21,30 @@ logger = logging.getLogger(__name__)
 
 def _get_channel_names(info: h5py.Group) -> list[str]:
     """
-    Extract and decode channel names from an HDF5 group's attributes.
+    Extract and decode channel names from the ARIS HDF5 DataSetInfo group.
 
     Parameters
     ----------
     info : h5py.Group
-        The HDF5 group containing the 'ChannelNames' attribute.
+        The '/DataSetInfo' group of the ARIS file.
 
     Returns
     -------
-    list[str]
-        A list of decoded channel name strings.
+    list of str
+        Decoded channel names.
     """
     return [decode_hdf5_attr(name) for name in info.attrs["ChannelNames"]]
 
 
-def _aris_initial_pixel_to_nm_scaling_h5(info: h5py.Group) -> float:
+def _aris_global_pixel_to_nm_scaling_h5(info: h5py.Group) -> float:
     """
     Extract pixel-to-nanometre scaling from an ARIS HDF5 DataSetInfo Global group.
 
-    This uses the fast scan axis (FastScanSize) and converts the physical scan size to
-    nanometres per pixel based on the numper of pixels per line (ScanPoints).
+    This uses the fast scan axis (FastScanSize) in meters and converts the physical
+    scan size to nanometres per pixel based on the number of pixels per line
+    (ScanPoints).
+
+    FastScanSize (in meters) / ScanPoints (number of pixels) * 1e9
 
     Parameters
     ----------
@@ -57,8 +59,11 @@ def _aris_initial_pixel_to_nm_scaling_h5(info: h5py.Group) -> float:
     Raises
     ------
     KeyError
-        If required attributes are missing in the DataSetInfo group.
+        If required attributes are missing.
+    ValueError
+        If ScanPoints is zero.
     """
+
     try:
         scan_width = info["Global/Parameters/Scan"].attrs[
             "FastScanSize"
@@ -81,6 +86,87 @@ def _aris_initial_pixel_to_nm_scaling_h5(info: h5py.Group) -> float:
         ) from e
 
 
+def _get_sorted_frame_keys(data: h5py.Group) -> list[str]:
+    """
+    Return frame keys sorted numerically.
+
+    ARIS frame datasets use keys like 'Frame 0', 'Frame 1', 'Frame 2'... .
+
+    Parameters
+    ----------
+    data : h5py.Group
+        The '/DataSet/Resolution 0' group containing frame datasets.
+
+    Returns
+    -------
+    list of str
+        Sorted frame keys.
+    """
+    data_keys = list(data.keys())
+    return sorted(data_keys, key=lambda k: int(k.split()[1]))
+
+
+def load_frames_and_scaling(
+    data: h5py.Group,
+    info: h5py.Group,
+    selected_ch: str,
+) -> tuple[np.ndarray, list[float]]:
+    """
+    Load all frames for the given channel and compute per-frame pixel sizes.
+
+    Parameters
+    ----------
+    data : h5py.Group
+        HDF5 group with frame/channel image data.
+    info : h5py.Group
+        HDF5 group containing metadata and per-frame overrides.
+    selected_ch : str
+        Channel name to extract.
+
+    Returns
+    -------
+    (ndarray, list of float)
+        3D stack array and per-frame pixel-size values (nm).
+    """
+    sorted_keys = _get_sorted_frame_keys(data)
+
+    initial_pixel_size_nm = _aris_global_pixel_to_nm_scaling_h5(info)
+    initial_scan_pixel_width = info["Global/Parameters/Scan"].attrs["ScanPoints"]
+
+    frames = []
+    pixel_sizes_nm = []
+    for frame_key in sorted_keys:
+        frames.append(data[frame_key][selected_ch]["Image"][:])
+        # If the scan size changes it is recorded in the per frame record in the
+        # metadata group
+        try:
+            new_scan_width = info["Frames"][frame_key]["Parameters"]["Scan"].attrs[
+                "FastScanSize"
+            ]
+        except (KeyError, AttributeError):
+            new_scan_width = None
+
+        if new_scan_width is None:
+            pixel_sizes_nm.append(initial_pixel_size_nm)
+        else:
+            try:
+                new_scan_points = info["Frames"][frame_key]["Parameters"]["Scan"].attrs[
+                    "ScanPoints"
+                ]
+            except (KeyError, AttributeError):
+                new_scan_points = None
+            if new_scan_points is None:
+                new_pixel_size = (new_scan_width / initial_scan_pixel_width) * 1e9
+            else:
+                new_pixel_size = (new_scan_width / new_scan_points) * 1e9
+
+            pixel_sizes_nm.append(new_pixel_size)
+
+    image_stack = np.stack(frames)
+
+    return image_stack, pixel_sizes_nm
+
+
 def load_aris(
     file_path: Path | str,
     channel: str,
@@ -93,7 +179,7 @@ def load_aris(
     Parameters
     ----------
     file_path : Path | str
-        Path to the .h5-jpk file.
+        Path to the .aris file.
     channel : str
         Channel to extract.
 
@@ -116,55 +202,19 @@ def load_aris(
         else:
             raise ValueError(f"Channel '{channel}' is not available.")
 
-        data_keys = list(data.keys())
-        sorted_keys = sorted(data_keys, key=lambda k: int(k.split()[1]))
-        frames = []
-        pixel_sizes_nm = []
-
-        initial_pixel_size_nm = _aris_initial_pixel_to_nm_scaling_h5(info)
-
-        initial_scan_pixel_width = info["Global/Parameters/Scan"].attrs["ScanPoints"]
-
-        for frame_key in sorted_keys:
-            frames.append(data[frame_key][selected_ch]["Image"][:])
-            # If the scan size changes it is recorded in the per frame record in the
-            # metadata group
-            try:
-                new_scan_width = info["Frames"][frame_key]["Parameters"]["Scan"].attrs[
-                    "FastScanSize"
-                ]
-            except (KeyError, AttributeError):
-                new_scan_width = None
-
-            if new_scan_width is None:
-                pixel_sizes_nm.append(initial_pixel_size_nm)
-            else:
-                try:
-                    new_scan_points = info["Frames"][frame_key]["Parameters"][
-                        "Scan"
-                    ].attrs["ScanPoints"]
-                except (KeyError, AttributeError):
-                    new_scan_points = None
-                if new_scan_points is None:
-                    new_pixel_size = (new_scan_width / initial_scan_pixel_width) * 1e9
-                else:
-                    new_pixel_size = (new_scan_width / new_scan_points) * 1e9
-
-                pixel_sizes_nm.append(new_pixel_size)
-
-        image_stack = np.stack(frames)
+        image_stack, pixel_sizes_nm = load_frames_and_scaling(data, info, selected_ch)
 
         # Read timestamps and line_rate
         timestamps = info["Series"]["Time"][:]
-        if len(timestamps) != len(sorted_keys):
+        if len(timestamps) != image_stack.shape[0]:
             raise ValueError(
-                f"Timestamp count ({len(timestamps)}) does not match frame count ({len(sorted_keys)})."  # noqa
+                f"Timestamp count ({len(timestamps)}) does not match frame count ({image_stack.shape[0]})."  # noqa
             )
         line_rate = info["Global/Parameters/Scan"].attrs["ScanRate"]
 
         # Compose per-frame metadata list
         frame_metadata = []
-        for frame in range(len(sorted_keys)):
+        for frame in range(image_stack.shape[0]):
             frame_metadata.append(
                 {
                     "timestamp": float(timestamps[frame]),
@@ -175,7 +225,7 @@ def load_aris(
 
         return AFMImageStack(
             data=image_stack,
-            pixel_size_nm=initial_pixel_size_nm,
+            pixel_size_nm=pixel_sizes_nm[0],
             channel=channel,
             file_path=str(file_path),
             frame_metadata=frame_metadata,

--- a/src/playnano/io/formats/read_aris.py
+++ b/src/playnano/io/formats/read_aris.py
@@ -154,7 +154,7 @@ def load_aris(
         timestamps = info["Series"]["Time"][:]
         if len(timestamps) != len(sorted_keys):
             raise ValueError(
-                f"Timestamp count ({len(timestamps)}) does not match frame count ({len(sorted_keys)})."
+                f"Timestamp count ({len(timestamps)}) does not match frame count ({len(sorted_keys)})."  # noqa
             )
         line_rate = info["Global/Parameters/Scan"].attrs["ScanRate"]
 

--- a/src/playnano/io/formats/read_aris.py
+++ b/src/playnano/io/formats/read_aris.py
@@ -1,0 +1,178 @@
+"""
+Module to decode and load .aris high speed AFM data files into a AFMImageStack object.
+
+Files containing multiple image frames are read together.
+"""
+
+import logging
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from playnano.afm_stack import AFMImageStack
+from playnano.utils.io_utils import decode_hdf5_attr
+
+logger = logging.getLogger(__name__)
+
+
+def _get_channel_names(info: h5py.Group) -> list[str]:
+    """
+    Extract and decode channel names from an HDF5 group's attributes.
+
+    Parameters
+    ----------
+    info : h5py.Group
+        The HDF5 group containing the 'ChannelNames' attribute.
+
+    Returns
+    -------
+    list[str]
+        A list of decoded channel name strings.
+    """
+    return [decode_hdf5_attr(name) for name in info.attrs["ChannelNames"]]
+
+
+def _aris_initial_pixel_to_nm_scaling_h5(info: h5py.Group) -> float:
+    """
+    Extract pixel-to-nanometre scaling from an ARIS HDF5 DataSetInfo Global group.
+
+    This uses the fast scan axis (FastScanSize) and converts the physical scan size to
+    nanometres per pixel based on the numper of pixels per line (ScanPoints).
+
+    Parameters
+    ----------
+    info : h5py.Group
+        HDF5 group containing the metadata associated with a DataSet (DataSetInfo).
+
+    Returns
+    -------
+    float
+        Real-world size of a single pixel in nanometres.
+
+    Raises
+    ------
+    KeyError
+        If required attributes are missing in the DataSetInfo group.
+    """
+    try:
+        scan_width = info["Global/Parameters/Scan"].attrs[
+            "FastScanSize"
+        ]  # physical length in meters
+        pixel_scan_width = info["Global/Parameters/Scan"].attrs[
+            "ScanPoints"
+        ]  # number of pixels
+
+        if pixel_scan_width == 0:
+            raise ValueError(
+                "Pixel count (ScanPoints) is zero; cannot compute scaling."
+            )
+
+        return (scan_width / pixel_scan_width) * 1e9
+
+    except KeyError as e:
+        missing = e.args[0]
+        raise KeyError(
+            f"Missing required attribute '{missing}' in HDF5 measurement group."
+        ) from e
+
+
+def load_aris(
+    file_path: Path | str,
+    channel: str,
+) -> AFMImageStack:
+    """
+    Load image stack from a Asylum Research .aris file, scaled to nanometers.
+
+    The images are loaded, reshaped into frames, and have timestamps generated.
+
+    Parameters
+    ----------
+    file_path : Path | str
+        Path to the .h5-jpk file.
+    channel : str
+        Channel to extract.
+
+    Returns
+    -------
+    AFMImageStack
+        Loaded AFM image stack with metadata and per-frame info.
+    """
+    file_path = Path(file_path)
+    with h5py.File(file_path, "r") as file:
+        data = file[
+            "/DataSet/Resolution 0"
+        ]  # where the image data is stored per frame per channel
+        info = file["/DataSetInfo"]  # where image metadata, channel names etc.
+
+        file_channels = _get_channel_names(info)
+
+        if channel in file_channels:
+            selected_ch = channel
+        else:
+            raise ValueError(f"Channel '{channel}' is not available.")
+
+        data_keys = list(data.keys())
+        sorted_keys = sorted(data_keys, key=lambda k: int(k.split()[1]))
+        frames = []
+        pixel_sizes_nm = []
+
+        initial_pixel_size_nm = _aris_initial_pixel_to_nm_scaling_h5(info)
+
+        initial_scan_pixel_width = info["Global/Parameters/Scan"].attrs["ScanPoints"]
+
+        for frame_key in sorted_keys:
+            frames.append(data[frame_key][selected_ch]["Image"][:])
+            # If the scan size changes it is recorded in the per frame record in the
+            # metadata group
+            try:
+                new_scan_width = info["Frames"][frame_key]["Parameters"]["Scan"].attrs[
+                    "FastScanSize"
+                ]
+            except (KeyError, AttributeError):
+                new_scan_width = None
+
+            if new_scan_width is None:
+                pixel_sizes_nm.append(initial_pixel_size_nm)
+            else:
+                try:
+                    new_scan_points = info["Frames"][frame_key]["Parameters"][
+                        "Scan"
+                    ].attrs["ScanPoints"]
+                except (KeyError, AttributeError):
+                    new_scan_points = None
+                if new_scan_points is None:
+                    new_pixel_size = (new_scan_width / initial_scan_pixel_width) * 1e9
+                else:
+                    new_pixel_size = (new_scan_width / new_scan_points) * 1e9
+
+                pixel_sizes_nm.append(new_pixel_size)
+
+        image_stack = np.stack(frames)
+
+        # Read timestamps and line_rate
+        timestamps = info["Series"]["Time"][:]
+        if len(timestamps) != len(sorted_keys):
+            raise ValueError(
+                f"Timestamp count ({len(timestamps)}) does not match frame count ({len(sorted_keys)})."
+            )
+        line_rate = info["Global/Parameters/Scan"].attrs["ScanRate"]
+
+        # Compose per-frame metadata list
+        frame_metadata = []
+        for frame in range(len(sorted_keys)):
+            frame_metadata.append(
+                {
+                    "timestamp": float(timestamps[frame]),
+                    "frame_pixel_size_nm": float(pixel_sizes_nm[frame]),
+                    "line_rate": float(line_rate),
+                }
+            )
+
+        return AFMImageStack(
+            data=image_stack,
+            pixel_size_nm=initial_pixel_size_nm,
+            channel=channel,
+            file_path=str(file_path),
+            frame_metadata=frame_metadata,
+        )

--- a/src/playnano/io/formats/read_aris.py
+++ b/src/playnano/io/formats/read_aris.py
@@ -1,7 +1,11 @@
 """
 Module to decode and load .aris high speed AFM data files into a AFMImageStack object.
 
-Files containing multiple image frames are read together.
+Files containing multiple image frames are read together. Since the frames in .aris
+files can be different sizes the pixel scaling value for the first frame is held as
+an AFMImageStack object (pixel_size_nm) while the values for indevidual frames are
+stored per frame in the frame_metadat list of dictionaries under the key,
+``frame_pixel_size_nm``.
 """
 
 import logging

--- a/src/playnano/io/formats/read_asd.py
+++ b/src/playnano/io/formats/read_asd.py
@@ -78,9 +78,17 @@ def load_asd_file(file_path: Path | str, channel: str) -> AFMImageStack:
     timestamps = np.arange(num_frames) * frame_interval
 
     # Compose per-frame metadata list
+    # Variable scan sizes/ pixel sizes not allowed in .asd files- simply use
+    # pixel_size_nm in all frame_metadata dictionaries.
     frame_metadata = []
     for ts in timestamps:
-        frame_metadata.append({"timestamp": ts, "line_rate": line_rate})
+        frame_metadata.append(
+            {
+                "timestamp": ts,
+                "frame_pixel_size_nm": pixel_size_nm,
+                "line_rate": line_rate,
+            }
+        )
 
     return AFMImageStack(
         data=image_stack,

--- a/src/playnano/io/formats/read_h5jpk.py
+++ b/src/playnano/io/formats/read_h5jpk.py
@@ -16,28 +16,10 @@ from playnano.utils.io_utils import (
     convert_height_units_to_nm,
     guess_height_data_units,
     height_units,
+    decode_hdf5_attr,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _decode_attr(attr: bytes | str) -> str:
-    """
-    Decode an attribute that may be bytes or a string.
-
-    Parameters
-    ----------
-    attr : bytes or str
-        The attribute to decode.
-
-    Returns
-    -------
-    str
-        The decoded string.
-    """
-    if isinstance(attr, bytes):
-        return attr.decode("utf-8")
-    return str(attr)
 
 
 def _attr_to_bool(attr: bytes | str | bool | int | float) -> bool:
@@ -55,7 +37,7 @@ def _attr_to_bool(attr: bytes | str | bool | int | float) -> bool:
         The boolean interpretation of the value.
     """
     if isinstance(attr, (bytes, str)):
-        return _decode_attr(attr).strip().lower() == "true"
+        return decode_hdf5_attr(attr).strip().lower() == "true"
     return bool(attr)
 
 
@@ -88,7 +70,7 @@ def _discover_available_channels(f: h5py.File) -> dict[str, str]:
 
             retrace = _attr_to_bool(c_group.attrs.get("retrace", False))
             tr_rt = "retrace" if retrace else "trace"
-            full_key = f"{_decode_attr(name).strip().lower()}_{tr_rt}"
+            full_key = f"{decode_hdf5_attr(name).strip().lower()}_{tr_rt}"
             full_path = f"{m_key}/{c_key}"
             if full_key not in channel_map:
                 channel_map[full_key] = full_path
@@ -419,7 +401,15 @@ def load_h5jpk(
         # Compose per-frame metadata list
         frame_metadata = []
         for ts in timestamps:
-            frame_metadata.append({"timestamp": ts, "line_rate": line_rate})
+            frame_metadata.append(
+                {
+                    "timestamp": ts,
+                    "frame_pixel_scan_nm": _jpk_pixel_to_nm_scaling_h5(
+                        measurement_group
+                    ),
+                    "line_rate": line_rate,
+                }
+            )
 
         return AFMImageStack(
             data=image_stack,

--- a/src/playnano/io/formats/read_h5jpk.py
+++ b/src/playnano/io/formats/read_h5jpk.py
@@ -14,9 +14,9 @@ import numpy as np
 from playnano.afm_stack import AFMImageStack
 from playnano.utils.io_utils import (
     convert_height_units_to_nm,
+    decode_hdf5_attr,
     guess_height_data_units,
     height_units,
-    decode_hdf5_attr,
 )
 
 logger = logging.getLogger(__name__)
@@ -404,7 +404,7 @@ def load_h5jpk(
             frame_metadata.append(
                 {
                     "timestamp": ts,
-                    "frame_pixel_scan_nm": _jpk_pixel_to_nm_scaling_h5(
+                    "frame_pixel_size_nm": _jpk_pixel_to_nm_scaling_h5(
                         measurement_group
                     ),
                     "line_rate": line_rate,

--- a/src/playnano/io/formats/read_jpk_folder.py
+++ b/src/playnano/io/formats/read_jpk_folder.py
@@ -105,7 +105,7 @@ def load_jpk_folder(
             frame_metadata.append(
                 {
                     "timestamp": ts,
-                    "frame_px_size_nm": px_size_nm,
+                    "frame_pixel_size_nm": px_size_nm,
                     "line_rate": line_rate,
                 }
             )

--- a/src/playnano/io/formats/read_jpk_folder.py
+++ b/src/playnano/io/formats/read_jpk_folder.py
@@ -95,8 +95,6 @@ def load_jpk_folder(
         img, px_size_nm = load_jpk(fpath, channel)
         if img.shape != (height_px, width_px):
             raise ValueError(f"Inconsistent image shape in {fpath}")
-        if not np.isclose(px_size_nm, first_pixel_size_nm):
-            raise ValueError(f"Inconsistent pixel size in {fpath}")
         if flip_image:
             img = np.flipud(img)
         image_stack[i] = img
@@ -104,7 +102,13 @@ def load_jpk_folder(
         # Compose per-frame metadata list
         frame_metadata = []
         for ts in timestamps:
-            frame_metadata.append({"timestamp": ts, "line_rate": line_rate})
+            frame_metadata.append(
+                {
+                    "timestamp": ts,
+                    "frame_px_size_nm": px_size_nm,
+                    "line_rate": line_rate,
+                }
+            )
 
     return AFMImageStack(
         data=image_stack,

--- a/src/playnano/io/formats/read_spm_folder.py
+++ b/src/playnano/io/formats/read_spm_folder.py
@@ -113,16 +113,14 @@ def load_spm_folder(folder_path: Path | str, channel: str) -> AFMImageStack:
     for i, fpath in enumerate(spm_files):
         logger.debug(f"Loading {fpath.name}")
         img, px_size_nm = spm.load_spm(fpath, channel)
-        if img.shape != (height_px, width_px):
-            raise ValueError(f"Inconsistent image shape in {fpath}")
-        if not np.isclose(px_size_nm, first_pixel_size_nm):
-            raise ValueError(f"Inconsistent pixel size in {fpath}")
         image_stack[i] = img
 
     # Compose per-frame metadata list
     frame_metadata = []
     for ts in timestamps:
-        frame_metadata.append({"timestamp": ts, "line_rate": line_rate})
+        frame_metadata.append(
+            {"timestamp": ts, "frame_pixel_size_nm": px_size_nm, "line_rate": line_rate}
+        )
 
     logger.debug(
         f"Loaded {num_frames} frames with shape {image_stack.shape} and pixel size"

--- a/src/playnano/io/formats/read_spm_folder.py
+++ b/src/playnano/io/formats/read_spm_folder.py
@@ -113,6 +113,8 @@ def load_spm_folder(folder_path: Path | str, channel: str) -> AFMImageStack:
     for i, fpath in enumerate(spm_files):
         logger.debug(f"Loading {fpath.name}")
         img, px_size_nm = spm.load_spm(fpath, channel)
+        if img.shape != (height_px, width_px):
+            raise ValueError(f"Inconsistent image shape in {fpath}")
         image_stack[i] = img
 
     # Compose per-frame metadata list
@@ -121,7 +123,6 @@ def load_spm_folder(folder_path: Path | str, channel: str) -> AFMImageStack:
         frame_metadata.append(
             {"timestamp": ts, "frame_pixel_size_nm": px_size_nm, "line_rate": line_rate}
         )
-
     logger.debug(
         f"Loaded {num_frames} frames with shape {image_stack.shape} and pixel size"
     )

--- a/src/playnano/io/gif_export.py
+++ b/src/playnano/io/gif_export.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 def create_gif_with_scale_and_timestamp(
     image_stack,
-    pixel_size_nm,
+    pixel_sizes_nm,
     timestamps=None,
     scale_bar_length_nm=100,
     output_path="output",
@@ -54,8 +54,8 @@ def create_gif_with_scale_and_timestamp(
     image_stack : np.ndarray
         3D array of shape (N, H, W) representing the AFM image stack.
 
-    pixel_size_nm : float
-        Size of each pixel in nanometers.
+    pixel_sizes_nm : list
+        List containing the size of a pixel in nanometers for each frame.
 
     timestamps : list[float] or tuple[float], optional
         Timestamps for each frame in seconds. If ``None`` or invalid,
@@ -121,6 +121,18 @@ def create_gif_with_scale_and_timestamp(
             "Invalid timestamps provided, will use frame indices as timestamps."
         )
 
+    # Check pixel_sizes_nm list
+
+    if (
+        pixel_sizes_nm is not None
+        and isinstance(pixel_sizes_nm, list)
+        and len(pixel_sizes_nm) == len(image_stack)
+    ):
+        pass
+    else:
+        draw_scale = False
+        logger.warning("Invalid pixel_sizes_nm list, will not draw scale bar.")
+
     if zmin is not None or zmax is not None:
         zmin_val, zmax_val = compute_zscale_range(image_stack, zmin, zmax)
     else:
@@ -134,7 +146,6 @@ def create_gif_with_scale_and_timestamp(
                 # Flat image: avoid division by zero, render as black
                 frame_norm = np.zeros_like(frame, dtype=np.uint8)
             else:
-                clipped = np.clip(frame, zmin_val, zmax_val)
                 clipped = np.clip(frame, zmin_val, zmax_val)
                 normalized = (clipped - zmin_val) / (zmax_val - zmin_val) * 255
                 normalized = np.nan_to_num(
@@ -158,11 +169,14 @@ def create_gif_with_scale_and_timestamp(
                 f"Invalid timestamps provided, using frame index {i} as timestamp."
             )
             timestamp = i
+
+        # Determine pixel_size_nm for frame
+        draw_pixel_size_nm = pixel_sizes_nm[i] if draw_scale else 1.0
         # Add annotations
         frame_with_overlay = draw_scale_and_timestamp(
             color_frame,
             timestamp=timestamp,
-            pixel_size_nm=pixel_size_nm,
+            pixel_size_nm=draw_pixel_size_nm,
             scale=1.0,
             bar_length_nm=scale_bar_length_nm,
             font_scale=frame.shape[0] / 256,
@@ -257,36 +271,28 @@ def export_gif(
 
     # Determine whether to use raw or processed data
     # (allows saving of unfiltered from play mode)
-    if raw is False:
-        stack_data = afm_stack.data
-        raw_exists = "raw" in afm_stack.processed
-        filtered_exists = raw_exists and any(
-            key != "raw" for key in afm_stack.processed.keys()
+    if raw and "raw" in afm_stack.processed:
+        stack_data = afm_stack.processed["raw"]
+        meta_src = afm_stack.state_backups.get(
+            "frame_metadata_before_edit", afm_stack.frame_metadata
         )
-        timestamps = [md["timestamp"] for md in afm_stack.frame_metadata]
+    else:
+        if raw:
+            logger.debug("Requested raw export on unprocessed data; using loaded data.")
+        stack_data = afm_stack.data
+        meta_src = afm_stack.frame_metadata
+        filtered_exists = "raw" in afm_stack.processed and any(
+            key != "raw" for key in afm_stack.processed
+        )
         if filtered_exists:
             base = f"{base}_filtered"
 
-    elif raw is True:
-        if "raw" in afm_stack.processed:
-            stack_data = afm_stack.processed["raw"]
-            if "frame_metadata_before_edit" in afm_stack.state_backups:
-                timestamps = [
-                    md["timestamp"]
-                    for md in afm_stack.state_backups.get(
-                        "frame_metadata_before_edit", afm_stack.frame_metadata
-                    )
-                ]
-            else:
-                timestamps = [md["timestamp"] for md in afm_stack.frame_metadata]
-        else:
-            logger.debug("Requested raw export on unprocessed data; using loaded data.")
-            stack_data = afm_stack.data
-            timestamps = [md["timestamp"] for md in afm_stack.frame_metadata]
+    timestamps = [md["timestamp"] for md in meta_src]
+    pixels_to_nm = [
+        md.get("frame_pixel_size_nm", afm_stack.pixel_size_nm) for md in meta_src
+    ]
 
     gif_path = out_dir / f"{base}.gif"
-
-    pixel_to_nm = afm_stack.pixel_size_nm
 
     # default scale bar
     bar_nm = scale_bar_nm if scale_bar_nm is not None else 100
@@ -294,7 +300,7 @@ def export_gif(
     logger.debug(f"[export] Writing GIF → {gif_path}")
     create_gif_with_scale_and_timestamp(
         stack_data,
-        pixel_to_nm,
+        pixels_to_nm,
         timestamps,
         output_path=gif_path,
         scale_bar_length_nm=bar_nm,

--- a/src/playnano/io/loader.py
+++ b/src/playnano/io/loader.py
@@ -102,19 +102,32 @@ def get_loader_for_file(
         If the file type is unsupported or better handled as a folder.
     """
     logger.debug(f"Determining loader for file {file_path}")
-    ext = file_path.suffix.lower()
-    if not ext:
+
+    suffixes = [s.lower() for s in file_path.suffixes]
+
+    # --- Case 1: no suffix at all ---
+    if not suffixes:
         raise ValueError(f"{file_path} has no extension and cannot be identified.")
 
+    # --- Case 2: multi-suffix formats like .ome.tif ---
+    multi = "".join(suffixes)  # e.g. [".ome", ".tif"] -> ".ome.tif"
+    if multi in file_loaders:
+        return multi, file_loaders[multi]
+
+    # --- Case 3: single suffix fallback ---
+    ext = suffixes[-1]  # always safe now
     if ext in file_loaders:
         return ext, file_loaders[ext]
-    elif ext in folder_loaders:
+
+    # --- Case 4: folder-only formats ---
+    if ext in folder_loaders:
         raise ValueError(
             f"The {ext} file type is typically a single-frame export."
             "To load HS-AFM video, pass the full folder instead."
         )
-    else:
-        raise ValueError(f"Unsupported file type: {ext}")
+
+    # --- Case 5: unsupported extension ---
+    raise ValueError(f"Unsupported file type: {ext}")
 
 
 def load_afm_stack(file_path: Path, channel: str = "height_trace") -> AFMImageStack:
@@ -162,7 +175,9 @@ def load_afm_stack(file_path: Path, channel: str = "height_trace") -> AFMImageSt
         ".aris": load_aris,
         ".npz": load_npz_bundle,
         ".h5": load_h5_bundle,
-        ".ome.tif": load_ome_tiff_stack,
+        # Currently, ".ome.tif" files are loaded with the same loader as .tif files.
+        # Sice Path.suffix only extrcts the string after the final '.' they are read as tiff
+        # ".ome.tif": load_ome_tiff_stack,
         ".tif": load_ome_tiff_stack,
         # Add others as needed
     }

--- a/src/playnano/io/loader.py
+++ b/src/playnano/io/loader.py
@@ -175,10 +175,10 @@ def load_afm_stack(file_path: Path, channel: str = "height_trace") -> AFMImageSt
         ".aris": load_aris,
         ".npz": load_npz_bundle,
         ".h5": load_h5_bundle,
-        # Currently, ".ome.tif" files are loaded with the same loader as .tif files.
-        # Sice Path.suffix only extrcts the string after the final '.' they are read as tiff
-        # ".ome.tif": load_ome_tiff_stack,
+        ".ome.tif": load_ome_tiff_stack,
         ".tif": load_ome_tiff_stack,
+        ".ome.tiff": load_ome_tiff_stack,
+        ".tiff": load_ome_tiff_stack,
         # Add others as needed
     }
 

--- a/src/playnano/io/loader.py
+++ b/src/playnano/io/loader.py
@@ -21,9 +21,9 @@ from playnano.io.data_loaders import (
     load_npz_bundle,
     load_ome_tiff_stack,
 )
+from playnano.io.formats.read_aris import load_aris
 from playnano.io.formats.read_asd import load_asd_file
 from playnano.io.formats.read_h5jpk import load_h5jpk
-from playnano.io.formats.read_aris import load_aris
 from playnano.io.formats.read_jpk_folder import load_jpk_folder
 from playnano.io.formats.read_spm_folder import load_spm_folder
 

--- a/src/playnano/io/loader.py
+++ b/src/playnano/io/loader.py
@@ -6,6 +6,7 @@ Supported extensions:
   - .spm        (folder)
   - .h5-jpk     (single-file JPK)
   - .asd        (single-file ASD)
+  - .ARIS       (single-file ARIS)
   - .ome.tif / .tif  (OME-TIFF bundles)
   - .npz        (playNano NPZ bundles)
   - .h5         (playNano HDF5 bundles)
@@ -22,6 +23,7 @@ from playnano.io.data_loaders import (
 )
 from playnano.io.formats.read_asd import load_asd_file
 from playnano.io.formats.read_h5jpk import load_h5jpk
+from playnano.io.formats.read_aris import load_aris
 from playnano.io.formats.read_jpk_folder import load_jpk_folder
 from playnano.io.formats.read_spm_folder import load_spm_folder
 
@@ -147,6 +149,7 @@ def load_afm_stack(file_path: Path, channel: str = "height_trace") -> AFMImageSt
     logger.debug(f"Resolved path: {file_path}")
     logger.debug(f"Loading AFM stack from {file_path} for channel '{channel}'")
 
+    # All file formats in lowercase
     folder_loaders = {
         ".jpk": load_jpk_folder,
         ".spm": load_spm_folder,
@@ -156,6 +159,7 @@ def load_afm_stack(file_path: Path, channel: str = "height_trace") -> AFMImageSt
     file_loaders = {
         ".h5-jpk": load_h5jpk,
         ".asd": load_asd_file,
+        ".aris": load_aris,
         ".npz": load_npz_bundle,
         ".h5": load_h5_bundle,
         ".ome.tif": load_ome_tiff_stack,

--- a/src/playnano/utils/io_utils.py
+++ b/src/playnano/utils/io_utils.py
@@ -302,3 +302,22 @@ def make_json_safe(obj):
         return obj.__name__
     else:
         return obj
+
+
+def decode_hdf5_attr(attr: bytes | str) -> str:
+    """
+    Decode an attribute that may be bytes or a string.
+
+    Parameters
+    ----------
+    attr : bytes or str
+        The attribute to decode.
+
+    Returns
+    -------
+    str
+        The decoded string.
+    """
+    if isinstance(attr, bytes):
+        return attr.decode("utf-8")
+    return str(attr)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -10,6 +10,13 @@ import numpy as np
 import pytest
 
 from playnano.afm_stack import AFMImageStack
+from playnano.io.formats.read_aris import (
+    _aris_global_pixel_to_nm_scaling_h5,
+    _get_channel_names,
+    _get_sorted_frame_keys,
+    load_aris,
+    load_frames_and_scaling,
+)
 from playnano.io.formats.read_asd import _standardize_units_to_nm, load_asd_file
 from playnano.io.formats.read_h5jpk import (
     _get_z_scaling_h5,
@@ -20,7 +27,7 @@ from playnano.io.formats.read_h5jpk import (
 )
 from playnano.io.formats.read_jpk_folder import load_jpk_folder
 from playnano.io.formats.read_spm_folder import load_spm_folder, parse_spm_header
-from playnano.io.loader import get_loader_for_folder
+from playnano.io.loader import get_loader_for_file, get_loader_for_folder
 
 
 def test_load_afm_stack_file_calls_correct_loader(tmp_path):
@@ -172,12 +179,129 @@ def test_get_loader_for_folder_detects_extension(tmp_path):
 
     folder_loaders = {
         ".jpk": lambda p: None,
-        ".asd": lambda p: None,
+        ".spm": lambda p: None,
     }
 
     ext, loader = get_loader_for_folder(tmp_path, folder_loaders)
     assert ext.lower() == ".jpk"
     assert callable(loader)
+
+
+def dummy_file_loader():
+    """Dummy a file loader for testing."""
+    pass
+
+
+def test_returns_correct_loader():
+    """Test that get_loader_for_file returns correct file loader."""
+    file_loaders = {".txt": dummy_file_loader}
+    folder_loaders = {}
+
+    ext, loader = get_loader_for_file(Path("test.txt"), file_loaders, folder_loaders)
+
+    assert ext == ".txt"
+    assert loader is dummy_file_loader
+
+
+def test_file_loader_raises_for_folder_loader_extension():
+    """Test that get_loader_for_file rises ValueError if passed folder loader file."""
+    file_loaders = {}
+    folder_loaders = {".hsa": "placeholder"}
+
+    with pytest.raises(ValueError) as excinfo:
+        get_loader_for_file(Path("frame.hsa"), file_loaders, folder_loaders)
+
+    assert "pass the full folder instead" in str(excinfo.value)
+
+
+def test_get_loader_for_file_raises_for_unsupported_extension():
+    """Test that get_loader_for_file raises a ValueError for an invalid extension."""
+    file_loaders = {}
+    folder_loaders = {}
+
+    with pytest.raises(ValueError) as excinfo:
+        get_loader_for_file(Path("data.weird"), file_loaders, folder_loaders)
+
+    assert "Unsupported file type" in str(excinfo.value)
+
+
+def test_get_loader_for_file_handles_multi_suffix():
+    """Test that get_loader_for_file handles multi suffix extentions."""
+    file_loaders = {".ome.tif": dummy_file_loader}
+    folder_loaders = {}
+    file = "test.ome.tif"
+    ext, loader = get_loader_for_file(Path(file), file_loaders, folder_loaders)
+
+    assert ext == ".ome.tif"
+    assert loader is dummy_file_loader
+
+
+def test_raises_for_missing_extension():
+    """Test that get_loader_for_file raises a ValueError for missing extension."""
+    file_loaders = {}
+    folder_loaders = {}
+
+    with pytest.raises(ValueError) as excinfo:
+        get_loader_for_file(Path("noextension"), file_loaders, folder_loaders)
+
+    assert "has no extension" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "ext",
+    [
+        ".h5-jpk",
+        ".asd",
+        ".aris",
+        ".npz",
+        ".h5",
+        ".tif",
+        ".ome.tif",
+        ".tiff",
+        ".ome.tiff",
+    ],
+)
+def test_get_loader_for_file_valid_all_formats(ext):
+    """Test that all file loaders open valid extensions."""
+
+    # Create a different dummy loader per extension
+    def dummy_loader():
+        """Dummy a loader for testing."""
+        return f"loaded {ext}"
+
+    file_loaders = {ext: dummy_loader}
+    folder_loaders = {}
+
+    # Simulate input file in lowercase
+    file_path = Path(f"test{ext}")
+
+    returned_ext, returned_loader = get_loader_for_file(
+        file_path, file_loaders, folder_loaders
+    )
+
+    assert returned_ext == ext
+    assert returned_loader is dummy_loader
+
+
+def test_get_loader_for_file_folder_conflict():
+    file_loaders = {}
+    folder_loaders = {".jpk": dummy_file_loader}
+
+    with pytest.raises(ValueError):
+        get_loader_for_file(Path("frame.jpk"), file_loaders, folder_loaders)
+
+
+def test_get_loader_for_file_unsupported():
+    file_loaders = {}
+    folder_loaders = {}
+
+    with pytest.raises(ValueError):
+        get_loader_for_file(Path("data.unknown"), file_loaders, folder_loaders)
+
+
+def test_get_loader_for_file_no_extension():
+    with pytest.raises(ValueError):
+        get_loader_for_file(Path("noext"), {}, {})
 
 
 def test_open_file(resource_path):
@@ -652,3 +776,161 @@ def test_read_spm_valid_files(
     assert all(isinstance(frame, metadata_dtype) for frame in result.frame_metadata)
     assert result.data.sum() == stack_sum
     assert len(result.frame_metadata) == result.data.shape[0]
+
+
+# --- ARIS loader tests ---
+
+
+def create_aris_file_on_disk(path: Path, num_frames=3, override_second_frame=False):
+    """
+    Create an in-memory ARIS-like HDF5 file for testing.
+
+    Do not have .ARIS  test data, so create some.
+
+    Parameters
+    ----------
+    num_frames : int, optional
+        Number of synthetic frames to generate (default: 3).
+    override_second_frame : bool, optional
+        If True, applies a per-frame pixel-scaling override to Frame 1
+        to test per-frame scan parameter handling.
+
+    Returns
+    -------
+    h5py.File
+        An in-memory HDF5 file configured like an ARIS dataset.
+    """
+
+    with h5py.File(path, "w") as f:
+
+        # --- DataSet structure ---
+        data_group = f.create_group("/DataSet/Resolution 0")
+        for i in range(num_frames):
+            frame_g = data_group.create_group(f"Frame {i}")
+            ch_g = frame_g.create_group("height_trace")
+            ch_g.create_dataset("Image", data=np.full((4, 4), i, float))
+
+        # --- DataSetInfo ---
+        info = f.create_group("/DataSetInfo")
+        info.attrs["ChannelNames"] = [b"height_trace"]
+
+        # Global params
+        gscan = info.create_group("Global/Parameters/Scan")
+        gscan.attrs["FastScanSize"] = 2e-6
+        gscan.attrs["ScanPoints"] = 256
+        gscan.attrs["ScanRate"] = 350.0
+
+        frames = info.create_group("Frames")
+
+        for i in range(num_frames):
+            p = frames.create_group(f"Frame {i}").create_group("Parameters/Scan")
+            p.attrs["FastScanSize"] = 2e-6
+            p.attrs["ScanPoints"] = 256
+
+        if override_second_frame and num_frames > 1:
+            p2 = frames["Frame 1"]["Parameters/Scan"]
+            p2.attrs["FastScanSize"] = 1e-6
+            p2.attrs["ScanPoints"] = 256
+
+        series = info.create_group("Series")
+        series.create_dataset("Time", data=np.arange(num_frames))
+
+    return path
+
+
+def test_get_channel_names(tmp_path):
+    """Test extraction of ARIS channel names."""
+    file_path = tmp_path / "test.aris"
+    create_aris_file_on_disk(file_path)
+
+    with h5py.File(file_path, "r") as f:
+        info = f["/DataSetInfo"]
+        channels = _get_channel_names(info)
+
+    assert channels == ["height_trace"]
+
+
+def test_global_pixel_scaling(tmp_path):
+    """Test computing global pixel size in nanometres."""
+    file_path = tmp_path / "test.aris"
+    create_aris_file_on_disk(file_path)
+
+    with h5py.File(file_path, "r") as f:
+        info = f["/DataSetInfo"]
+        pixel_size = _aris_global_pixel_to_nm_scaling_h5(info)
+
+    assert np.isclose(pixel_size, 7.8125)
+
+
+def test_sorted_frame_keys(tmp_path):
+    """Test numeric sorting of ARIS frame keys."""
+    file_path = tmp_path / "test.aris"
+    create_aris_file_on_disk(file_path)
+
+    with h5py.File(file_path, "r") as f:
+        data = f["/DataSet/Resolution 0"]
+        keys = _get_sorted_frame_keys(data)
+
+    assert keys == ["Frame 0", "Frame 1", "Frame 2"]
+
+
+def test_load_frames_without_override(tmp_path):
+    """Test frame loading when no per-frame scaling override is used."""
+    file_path = tmp_path / "test.aris"
+    create_aris_file_on_disk(file_path)
+
+    with h5py.File(file_path, "r") as f:
+        data = f["/DataSet/Resolution 0"]
+        info = f["/DataSetInfo"]
+        stack, pixel_sizes = load_frames_and_scaling(data, info, "height_trace")
+
+    assert stack.shape == (3, 4, 4)
+    assert np.all(stack[2] == 2)
+    assert all(np.isclose(px, pixel_sizes[0]) for px in pixel_sizes)
+
+
+def test_load_frames_with_override(tmp_path):
+    """Test per-frame scaling override for Frame 1."""
+    file_path = tmp_path / "test.aris"
+    create_aris_file_on_disk(file_path, override_second_frame=True)
+
+    with h5py.File(file_path, "r") as f:
+        data = f["/DataSet/Resolution 0"]
+        info = f["/DataSetInfo"]
+        stack, pixel_sizes = load_frames_and_scaling(data, info, "height_trace")
+
+    assert not np.isclose(pixel_sizes[0], pixel_sizes[1])
+
+
+def test_load_aris_returns_correct_type(tmp_path):
+    """Test that load_aris returns an AFMImageStack."""
+    file_path = tmp_path / "test.aris"
+    create_aris_file_on_disk(file_path)
+
+    result = load_aris(file_path, "height_trace")
+
+    assert isinstance(result, AFMImageStack)
+    assert result.data.shape == (3, 4, 4)
+
+
+def test_load_aris_raises_missing_channel(tmp_path):
+    """Test error raised when loading a missing ARIS channel."""
+    file_path = tmp_path / "test.aris"
+    create_aris_file_on_disk(file_path)
+
+    with pytest.raises(ValueError):
+        load_aris(file_path, "nonexistent")
+
+
+def test_load_aris_timestamp_mismatch(tmp_path):
+    """Test error raised when timestamps do not match frame count."""
+    file_path = tmp_path / "bad.aris"
+    create_aris_file_on_disk(file_path)
+
+    # Replace timestamps with too few values
+    with h5py.File(file_path, "a") as f:
+        del f["/DataSetInfo/Series/Time"]
+        f["/DataSetInfo/Series"].create_dataset("Time", data=np.array([0.0, 1.0]))
+
+    with pytest.raises(ValueError):
+        load_aris(file_path, "height_trace")

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -607,29 +607,6 @@ def test_load_spm_folder_inconsistent_shape_raises(
         load_spm_folder(tmp_path, channel="height")
 
 
-@patch("playnano.io.formats.read_spm_folder.spm.load_spm")
-@patch("playnano.io.formats.read_spm_folder.parse_spm_header")
-def test_load_spm_folder_inconsistent_pixel_size_raises(
-    mock_parse_header, mock_load_spm, tmp_path
-):
-    """Test `load_spm_folder` raises ValueError for inconsistent pixel sizes."""
-    # Create two dummy .spm files
-    f1 = tmp_path / "frame1.spm"
-    f2 = tmp_path / "frame2.spm"
-    f1.write_text("placeholder")
-    f2.write_text("placeholder")
-
-    # Same shape, but pixel sizes differ
-    mock_load_spm.side_effect = [
-        (np.ones((10, 10)), 1.0),
-        (np.ones((10, 10)), 2.0),
-    ]
-    mock_parse_header.return_value = {"Scan Rate": "10"}
-
-    with pytest.raises(ValueError, match="Inconsistent pixel size"):
-        load_spm_folder(tmp_path, channel="height")
-
-
 @pytest.mark.parametrize(
     (
         "folder_name",

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -188,7 +188,7 @@ def test_get_loader_for_folder_detects_extension(tmp_path):
 
 
 def dummy_file_loader():
-    """Dummy a file loader for testing."""
+    """Make a dummy file loader for testing."""
     pass
 
 
@@ -266,7 +266,7 @@ def test_get_loader_for_file_valid_all_formats(ext):
 
     # Create a different dummy loader per extension
     def dummy_loader():
-        """Dummy a loader for testing."""
+        """Make a dummy loader for testing."""
         return f"loaded {ext}"
 
     file_loaders = {ext: dummy_loader}
@@ -284,6 +284,7 @@ def test_get_loader_for_file_valid_all_formats(ext):
 
 
 def test_get_loader_for_file_folder_conflict():
+    """Test that get_loader_for_file raises a ValueError when given a file format."""
     file_loaders = {}
     folder_loaders = {".jpk": dummy_file_loader}
 
@@ -292,6 +293,7 @@ def test_get_loader_for_file_folder_conflict():
 
 
 def test_get_loader_for_file_unsupported():
+    """Test that get_loader_for_file raises a ValueError for unknown extension."""
     file_loaders = {}
     folder_loaders = {}
 
@@ -300,6 +302,7 @@ def test_get_loader_for_file_unsupported():
 
 
 def test_get_loader_for_file_no_extension():
+    """Test that get_loader_for_file raises a ValueError for no extension."""
     with pytest.raises(ValueError):
         get_loader_for_file(Path("noext"), {}, {})
 
@@ -802,7 +805,6 @@ def create_aris_file_on_disk(path: Path, num_frames=3, override_second_frame=Fal
     """
 
     with h5py.File(path, "w") as f:
-
         # --- DataSet structure ---
         data_group = f.create_group("/DataSet/Resolution 0")
         for i in range(num_frames):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -904,6 +904,37 @@ def test_load_frames_with_override(tmp_path):
     assert not np.isclose(pixel_sizes[0], pixel_sizes[1])
 
 
+def test_load_frames_reverts_to_global_pixel_size(tmp_path):
+    """Test per-frame scaling falls back to global scale when missing."""
+    file_path = tmp_path / "missing_frame_pixel.aris"
+    create_aris_file_on_disk(file_path)
+
+    # Set a new global FastScanSize to verify fallback behaviour
+    new_global_scan_size = 2e-7  # 0.2 µm
+    expected_pixel_nm = (new_global_scan_size / 256) * 1e9
+
+    with h5py.File(file_path, "a") as f:
+        # Modify global scan size
+        f["/DataSetInfo/Global/Parameters/Scan"].attrs[
+            "FastScanSize"
+        ] = new_global_scan_size
+
+        # Remove per-frame scan metadata (so loader must fall back)
+        for i in range(3):
+            try:
+                del f[f"/DataSetInfo/Frames/Frame {i}/Parameters/Scan"]
+            except KeyError:
+                pass  # already missing -> fine
+
+        data = f["/DataSet/Resolution 0"]
+        info = f["/DataSetInfo"]
+        _, pixel_sizes = load_frames_and_scaling(data, info, "height_trace")
+
+    # Validate fallback for all frames
+    for px in pixel_sizes:
+        assert np.isclose(px, expected_pixel_nm)
+
+
 def test_load_aris_returns_correct_type(tmp_path):
     """Test that load_aris returns an AFMImageStack."""
     file_path = tmp_path / "test.aris"

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -54,6 +54,7 @@ def test_mainwindow_loads_and_interacts(mock_load_data, qtbot):
     mock_stack.analysis = {}
     mock_stack.add_analysis = MagicMock()
     mock_stack.time_for_frame = MagicMock(return_value=0.1)
+    mock_stack.scaling_for_frame = MagicMock(return_value=1.0)
     mock_load_data.return_value = mock_stack
     mock_stack.pixel_size_nm = 1.0
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -372,11 +372,12 @@ def test_create_gif_with_scale_and_timestamp_outputs_gif(tmp_path):
     # Create a 3-frame dummy image stack
     stack = np.random.rand(3, 10, 10)
     timestamps = [0.0, 1.0, 2.0]
+    pixel_sizes_nm = [1.0, 1.0, 1.0]
     output_path = tmp_path / "test_output.gif"
 
     create_gif_with_scale_and_timestamp(
         image_stack=stack,
-        pixel_size_nm=1.0,
+        pixel_sizes_nm=pixel_sizes_nm,
         timestamps=timestamps,
         scale_bar_length_nm=5,
         output_path=output_path,
@@ -398,12 +399,13 @@ def test_create_gif_with_flat_data(tmp_path):
     """Test that GIF creation handles flat data without crashing."""
     image_stack = np.zeros((3, 4, 4))  # flat stack
     timestamps = [0, 1, 2]
+    pixel_sizes_nm = [1.0, 1.0, 1.0]
     output_path = tmp_path / "test.gif"
 
     with patch("PIL.Image.Image.save") as mock_save:
         create_gif_with_scale_and_timestamp(
             image_stack=image_stack,
-            pixel_size_nm=1.0,
+            pixel_sizes_nm=pixel_sizes_nm,
             timestamps=timestamps,
             output_path=str(output_path),
             zmin=None,
@@ -434,13 +436,14 @@ def test_create_gif_with_various_zscales(zmin, zmax):
     )
 
     timestamps = [0.0, 1.0]
+    pixel_sizes_nm = [1.0, 1.0]
 
     with TemporaryDirectory() as tmp:
         out_path = Path(tmp) / "test.gif"
 
         create_gif_with_scale_and_timestamp(
             image_stack=stack,
-            pixel_size_nm=1.0,
+            pixel_sizes_nm=pixel_sizes_nm,
             timestamps=timestamps,
             scale_bar_length_nm=50,
             output_path=str(out_path),
@@ -522,7 +525,7 @@ def test_fallback_to_index_on_bad_timestamp(bad_timestamps, tmp_path):
 
         create_gif_with_scale_and_timestamp(
             image_stack=image_stack,
-            pixel_size_nm=1.0,
+            pixel_sizes_nm=[1.0, 1.0, 1.0],
             timestamps=ts,
             output_path=output_path,
             scale_bar_length_nm=50,
@@ -538,6 +541,7 @@ def test_fallback_to_index_if_no_timestamps(tmp_path):
     """Test that gif_export falls back to frame index if there are no timestamps."""
     image_stack = np.ones((2, 2, 2), dtype=float)
     bad_timestamps = "invalid type"
+    pixel_sizes_nm = [1.0, 1.0]
 
     output_path = tmp_path / "test.gif"
 
@@ -546,7 +550,7 @@ def test_fallback_to_index_if_no_timestamps(tmp_path):
 
         create_gif_with_scale_and_timestamp(
             image_stack=image_stack,
-            pixel_size_nm=1.0,
+            pixel_sizes_nm=pixel_sizes_nm,
             timestamps=bad_timestamps,
             output_path=output_path,
             scale_bar_length_nm=50,
@@ -622,16 +626,19 @@ def dummy_stack():
     data = np.random.rand(3, 4, 4).astype(np.float32)
     timestamps = [0.0, 1.0, 2.0]
     metadata = [{"timestamp": t} for t in timestamps]
-    return data, timestamps, metadata
+    for frame in metadata:
+        frame["frame_pixel_size_nm"] = 1.0
+    px2nm = 1.0
+    return data, timestamps, metadata, px2nm
 
 
 @pytest.fixture
 def afm_stack_obj(dummy_stack):
     """Generate a dummy AFMImageStack object."""
-    data, timestamps, metadata = dummy_stack
+    data, timestamps, metadata, px2nm = dummy_stack
     stack = AFMImageStack(
         data=data,
-        pixel_size_nm=1.0,
+        pixel_size_nm=px2nm,
         frame_metadata=metadata,
         file_path="dummy_path.h5-jpk",
         channel="height_trace",
@@ -643,10 +650,10 @@ def afm_stack_obj(dummy_stack):
 
 def test_save_ome_tiff_stack_creates_file(dummy_stack):
     """Test that save_tiff_bundle creates a file."""
-    data, timestamps, metadata = dummy_stack
+    data, timestamps, metadata, px2nm = dummy_stack
     stack = AFMImageStack(
         data=data,
-        pixel_size_nm=1.0,
+        pixel_size_nm=px2nm,
         file_path="dummy_path.h5-jpk",
         frame_metadata=metadata,
         channel="height_trace",
@@ -661,11 +668,11 @@ def test_save_ome_tiff_stack_creates_file(dummy_stack):
 
 def test_save_npz_bundle_creates_file(dummy_stack):
     """Test that save_npz_bundle creates a file."""
-    data, timestamps, metadata = dummy_stack
+    data, timestamps, metadata, px2nm = dummy_stack
     stack = AFMImageStack(
         data=data,
         file_path="dummy_path.h5-jpk",
-        pixel_size_nm=1.0,
+        pixel_size_nm=px2nm,
         frame_metadata=metadata,
         channel="height_trace",
     )
@@ -682,10 +689,10 @@ def test_save_npz_bundle_creates_file(dummy_stack):
 
 def test_save_h5_bundle_creates_file(dummy_stack):
     """Test that save_h5_bundle creates a file."""
-    data, timestamps, metadata = dummy_stack
+    data, timestamps, metadata, px2nm = dummy_stack
     stack = AFMImageStack(
         data=data,
-        pixel_size_nm=1.0,
+        pixel_size_nm=px2nm,
         file_path="dummy_path.h5-jpk",
         frame_metadata=metadata,
         channel="height_trace",
@@ -1073,6 +1080,8 @@ def test_ome_tif_export_and_reload_synthetic(tmp_path):
     raw_data = np.random.rand(n_frames, H, W).astype(np.float32)
     processed_data = raw_data + 1.0
     meta = [{"timestamp": i} for i in range(n_frames)]
+    for frame in meta:
+        frame["frame_pixel_size_nm"] = 2.0
 
     stack = AFMImageStack(
         data=processed_data,

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -954,6 +954,25 @@ def stack_with_times():
         yield stack
 
 
+@pytest.fixture
+def stack_with_frame_px():
+    """Test AFMImageStack with frame_pixel_size_nm values."""
+    # Create small data and metadata
+    data = np.zeros((4, 2, 2), dtype=float)
+    # frame_metadata: first has timestamp 0.0, second missing, third 2.5, fourth missing
+    meta = [{"frame_pixel_size_nm": 2.0}, {}, {"frame_pixel_size_nm": 3.0}, {}]
+    # Use TemporaryDirectory for file_path
+    with TemporaryDirectory() as td:
+        stack = AFMImageStack(
+            data.copy(),
+            pixel_size_nm=1.0,
+            channel="h",
+            file_path=Path(td),
+            frame_metadata=meta,
+        )
+        yield stack
+
+
 # --- Tests for AFMImageStack time methods ---
 
 
@@ -965,6 +984,16 @@ def test_time_for_frame_with_and_without_timestamp(stack_with_times):
     assert stack.time_for_frame(1) == 1.0
     assert pytest.approx(stack.time_for_frame(2)) == 2.5
     assert stack.time_for_frame(3) == 3.0
+
+
+def test_scaling_for_frame_with_and_without_frame_pixel_size(stack_with_frame_px):
+    """scaling_for_frame should return frame pixel value or the initial as float."""
+    stack = stack_with_frame_px
+    assert stack.scaling_for_frame(0) == 2.0
+    # missing timestamp: fallback to index
+    assert stack.scaling_for_frame(1) == 1.0
+    assert pytest.approx(stack.scaling_for_frame(2)) == 3.0
+    assert stack.scaling_for_frame(3) == 1.0
 
 
 def test_get_frame_times(stack_with_times):


### PR DESCRIPTION
Added a reader for the .ARIS file format. Since the Cypher Asylum Research system that creates these files allow the physical scan size to change during scanning these files can contain variable pixel scaling factors.

To allow for this the original `pixel_size_nm` is retained but is now set to the pixel scaling factor for the first frame or 'Global' value. The scaling factors for individual frames are now held in the `frame_metadata` dictionaries as `frame_pixel_size_nm` which are now used in the GUI and for GIF generation. 