### PR TITLE
Bug/frame pixel size nm creation + support python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Official support for Python 3.13
-- - Compatibility with NumPy 2.x (including NumPy 2.0+)
+- Compatibility with NumPy 2.x (including NumPy 2.0+)
 
 #### Processing filters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Official support for Python 3.13
+- - Compatibility with NumPy 2.x (including NumPy 2.0+)
+
 #### Processing filters
 
 - **Flip filter**
@@ -20,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### File readers
 
 - **ARIS reader**
-  - Support for loading Asylum Research **`.aris`** high-speed AFM data files.
+  - Support for loading Asylum Research **``.aris``** high-speed AFM data files.
   - Comprehensive ARIS loader including:
     - Channel-name extraction from HDF5 metadata.
     - Global and per-frame pixel-size scaling with well-defined fallback behaviour.
@@ -136,12 +139,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated pre-commit configuration, including Ruff, Black, isort and markdownlint
   version alignment and formatting fixes.
 
+#### Tests
+
+- Improved numerical robustness in tests (floating-point comparisons now use tolerances for cross-platform consistency)
+- Added Python 3.13 to the test matrix
+
 ---
 
 ### Fixed
 
 - Fixed loader errors relating to missing file extensions and no-suffix inputs.
-- Connected FPS calculation based on ``line_rate`` into the GUI playback logic.
+- Connected FPS calculation based on ``line_rate`` to GUI playback logic.
+- Fixed `frame_metadata` construction to ensure one entry per frame (previously overwritten or
+  incomplete in some loaders, notably `.spm` and `.jpk`)
+- Standardised metadata structure across all formats:
+  - `timestamp`
+  - `frame_pixel_size_nm`
+  - `line_rate`
+- Clarified pixel size behaviour per format:
+  - Per-frame (`.jpk`, `.aris`, `.spm`)
+  - Constant (`.h5-jpk`, `.asd`)
+- Updated docstrings to document pixel size semantics and usage
 
 ## [0.3.1] - 2026-03-12
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Please read this guide before submitting a pull request.
 ### Prerequisites
 
 - [Anaconda or Miniconda](https://docs.conda.io/en/latest/miniconda.html)
-- Python 3.10–3.12
+- Python 3.10–3.13
 
 ### Setting up a development environment
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Learn more about the motivation, design, and structure of playNano in the [Intro
 
 </div>
 
-This project requires Python 3.10 - 3.12 and is in development. If you find any issues, please open an issue at:
+This project requires Python 3.10 - 3.13 and is in development. If you find any issues, please open an issue at:
 <https://github.com/derollins/playNano/issues>
 
 Questions? Email: <d.e.rollins@leeds.ac.uk>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 <div align="center">
 
 [![GitHub release](https://img.shields.io/github/v/release/derollins/playNano?color=green)](https://github.com/derollins/playNano/releases)
-[![GitHub release downloads](https://img.shields.io/github/downloads/derollins/playNano/latest/total?color=green)](https://github.com/derollins/playNano/releases)
 [![PyPI version](https://img.shields.io/pypi/v/playNano?color=blue)](https://pypi.org/project/playNano/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/playNano?color=blue)](https://pypi.org/project/playNano/)
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue?logo=github)](https://derollins.github.io/playNano/)
@@ -68,7 +67,7 @@ Full documentation: <https://derollins.github.io/playNano/>
 
 ## 📦 Installation and Dependencies
 
-**Python compatibility:** 3.10 – 3.12
+**Python compatibility:** 3.10 – 3.13
 
 It is recommended to use a virtual environment such as conda to isolate the installation. There
 are instructions on how to do this in the docs: [Installation](https://derollins.github.io/playNano/main/installation.html)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,14 +11,9 @@ as well as through GitHub.
 System requirements
 -------------------
 
-- Python **3.10 - 3.12** (3.11 recommended)
+- Python **3.10 - 3.13** (3.11 recommended)
 - Linux, macOS, or Windows
 - Internet connection for downloading packages
-
-.. note::
-
-   NumPy is currently pinned to ``<2.0`` for compatibility with some
-   scientific libraries. See the :doc:`changelog` for updates.
 
 Installation Guide
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ known_first_party = ["playnano"]
 
 [tool.black]
 line-length = 88
-target-version = ['py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "playnano"
 dynamic = ["version"]
 description = "Python toolkit for processing, analysing and visualising high-speed AFM (Atomic Force Microscopy) video data."
 readme = "README.md"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10,<3.14"
 authors = [
   { name = "Daniel E. Rollins", email = "d.e.rollins@leeds.ac.uk" }
 ]
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 keywords = [
   # Core domain
@@ -59,7 +60,7 @@ keywords = [
   "surface analysis",
 ]
 dependencies = [
-  "numpy>=1.23,<2.0",
+  "numpy>=1.23",
   "pandas",
   "h5py",
   "Pillow",
@@ -148,7 +149,7 @@ known_first_party = ["playnano"]
 
 [tool.black]
 line-length = 88
-target-version = ['py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312', 'py313']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/src/playnano/analysis/pipeline.py
+++ b/src/playnano/analysis/pipeline.py
@@ -155,7 +155,7 @@ class AnalysisPipeline:
 
         # 2) Entry points (plugin mechanism)
         if cls is None:
-            # Modern API available on Python 3.10–3.12
+            # Modern API available on Python 3.10–3.13
             eps = metadata.entry_points().select(
                 group="playnano.analysis", name=module_name
             )

--- a/src/playnano/io/export_data.py
+++ b/src/playnano/io/export_data.py
@@ -375,11 +375,11 @@ def save_h5_bundle(path: Path, stack: AFMImageStack, raw: bool = False) -> None:
         provenance_clean = make_json_safe(stack.provenance)
         provenance_json = json.dumps(provenance_clean).encode("utf-8")
 
-        f.create_dataset("frame_metadata_json", data=np.string_(json.dumps(meta_src)))
-        f.create_dataset("provenance_json", data=np.string_(provenance_json))
+        f.create_dataset("frame_metadata_json", data=np.bytes_(json.dumps(meta_src)))
+        f.create_dataset("provenance_json", data=np.bytes_(provenance_json))
         if getattr(stack, "state_backups", None):
             f.create_dataset(
-                "state_backups_json", data=np.string_(json.dumps(stack.state_backups))
+                "state_backups_json", data=np.bytes_(json.dumps(stack.state_backups))
             )
 
         # --- Root attributes ---

--- a/src/playnano/io/formats/read_aris.py
+++ b/src/playnano/io/formats/read_aris.py
@@ -187,6 +187,12 @@ def load_aris(
     -------
     AFMImageStack
         Loaded AFM image stack with metadata and per-frame info.
+
+    Notes
+    -----
+    Pixel size may vary between frames in ARIS files. The global
+    `pixel_size_nm` attribute corresponds to the first frame, while
+    per-frame values are stored in `frame_metadata`.
     """
     file_path = Path(file_path)
     with h5py.File(file_path, "r") as file:

--- a/src/playnano/io/formats/read_h5jpk.py
+++ b/src/playnano/io/formats/read_h5jpk.py
@@ -363,6 +363,15 @@ def load_h5jpk(
     -------
     AFMImageStack
         Loaded AFM image stack with metadata and per-frame info.
+
+    Notes
+    -----
+    In .h5-jpk files, the pixel size is defined at the measurement level and
+    is constant across all frames. Therefore, `frame_pixel_size_nm` is identical
+    for every frame.
+
+    This differs from .jpk and .spm folder-based data, where pixel size may vary
+    between frames and is stored per-frame.
     """
     file_path = Path(file_path)
 

--- a/src/playnano/io/formats/read_jpk_folder.py
+++ b/src/playnano/io/formats/read_jpk_folder.py
@@ -89,8 +89,11 @@ def load_jpk_folder(
     frame_interval = 1.0 / frame_rate  # time taken per frame
     timestamps = np.arange(num_frames) * frame_interval
 
+    frame_metadata = []
+
     # Load all images
     for i, fpath in enumerate(jpk_files):
+        ts = timestamps[i]
         logger.debug(f"Loading {fpath.name}")
         img, px_size_nm = load_jpk(fpath, channel)
         if img.shape != (height_px, width_px):
@@ -100,15 +103,13 @@ def load_jpk_folder(
         image_stack[i] = img
 
         # Compose per-frame metadata list
-        frame_metadata = []
-        for ts in timestamps:
-            frame_metadata.append(
-                {
-                    "timestamp": ts,
-                    "frame_pixel_size_nm": px_size_nm,
-                    "line_rate": line_rate,
-                }
-            )
+        frame_metadata.append(
+            {
+                "timestamp": ts,
+                "frame_pixel_size_nm": px_size_nm,
+                "line_rate": line_rate,
+            }
+        )
 
     return AFMImageStack(
         data=image_stack,

--- a/src/playnano/io/formats/read_spm_folder.py
+++ b/src/playnano/io/formats/read_spm_folder.py
@@ -120,13 +120,12 @@ def load_spm_folder(folder_path: Path | str, channel: str) -> AFMImageStack:
             raise ValueError(f"Inconsistent image shape in {fpath}")
         image_stack[i] = img
 
-    # Compose per-frame metadata list
-    frame_metadata.append(
-        {"timestamp": ts, "frame_pixel_size_nm": px_size_nm, "line_rate": line_rate}
-    )
-    logger.debug(
-        f"Loaded {num_frames} frames with shape {image_stack.shape} and pixel size"
-    )
+        # Compose per-frame metadata list
+        frame_metadata.append(
+            {"timestamp": ts, "frame_pixel_size_nm": px_size_nm, "line_rate": line_rate}
+        )
+
+    logger.debug(f"Loaded {num_frames} frames with shape {image_stack.shape}.")
 
     return AFMImageStack(
         data=image_stack,

--- a/src/playnano/io/formats/read_spm_folder.py
+++ b/src/playnano/io/formats/read_spm_folder.py
@@ -109,8 +109,11 @@ def load_spm_folder(folder_path: Path | str, channel: str) -> AFMImageStack:
     frame_interval = 1.0 / frame_rate  # time taken per frame
     timestamps = np.arange(num_frames) * frame_interval
 
+    frame_metadata = []
+
     # Load all images
     for i, fpath in enumerate(spm_files):
+        ts = timestamps[i]
         logger.debug(f"Loading {fpath.name}")
         img, px_size_nm = spm.load_spm(fpath, channel)
         if img.shape != (height_px, width_px):
@@ -118,11 +121,9 @@ def load_spm_folder(folder_path: Path | str, channel: str) -> AFMImageStack:
         image_stack[i] = img
 
     # Compose per-frame metadata list
-    frame_metadata = []
-    for ts in timestamps:
-        frame_metadata.append(
-            {"timestamp": ts, "frame_pixel_size_nm": px_size_nm, "line_rate": line_rate}
-        )
+    frame_metadata.append(
+        {"timestamp": ts, "frame_pixel_size_nm": px_size_nm, "line_rate": line_rate}
+    )
     logger.debug(
         f"Loaded {num_frames} frames with shape {image_stack.shape} and pixel size"
     )

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -457,7 +457,7 @@ def test_read_asd_valid_file(
     assert result.data.dtype == np.dtype(image_dtype)
     assert isinstance(result.frame_metadata, list)
     assert all(isinstance(frame, metadata_dtype) for frame in result.frame_metadata)
-    assert result.data.sum() == stack_sum
+    assert result.data.sum() == pytest.approx(stack_sum, rel=1e-12)
     assert len(result.frame_metadata) == result.data.shape[0]
 
 
@@ -777,7 +777,7 @@ def test_read_spm_valid_files(
     assert result.data.dtype == np.dtype(image_dtype)
     assert isinstance(result.frame_metadata, list)
     assert all(isinstance(frame, metadata_dtype) for frame in result.frame_metadata)
-    assert result.data.sum() == stack_sum
+    assert result.data.sum() == pytest.approx(stack_sum, rel=1e-12)
     assert len(result.frame_metadata) == result.data.shape[0]
 
 


### PR DESCRIPTION
## Summary

Fix per-frame metadata bugs and standardise metadata handling across AFM loaders.

## Changes

- Fixed `frame_metadata` construction to ensure one entry per frame (previously overwritten or incomplete in some loaders, notably `.spm` and `.jpk`)
- Standardised metadata structure across all formats:
  - `timestamp`
  - `frame_pixel_size_nm`
  - `line_rate`
- Clarified pixel size behaviour per format:
  - Per-frame (`.jpk`, `.aris`, `.spm`)
  - Constant (`.h5-jpk`, `.asd`)
- Updated docstrings to document pixel size semantics and usage

## Impact

- Correct per-frame scaling and timestamps
- Consistent API across loaders
- Improved reliability for downstream analysis
