### PR TITLE
add: drop_final_frames processing function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: ^(docs/|tests/resources/spm_folder_0|src/playnano/resources/fonts/|LICENSE)

--- a/docs/processing-operations-reference.rst
+++ b/docs/processing-operations-reference.rst
@@ -136,10 +136,13 @@ method.
      - Parameters
    * - :func:`~playnano.processing.stack_edit.drop_frames`
      - Remove specific frames from a 3D array. Does not modify the input array.
-     - data (ndarray, 3D), indices_to_drop (list of int)
+     - data (ndarray, 3D), indices_to_drop (list of int).
    * - :func:`~playnano.processing.stack_edit.drop_frame_range`
      - Generate a list of frame indices to drop within a specified start (inclusive) to end (exclusive) range.
-     - data (ndarray, 3D), start (int, inclusive), end (int, exclusive)
+     - data (ndarray, 3D), start (int, inclusive), end (int, exclusive).
    * - :func:`~playnano.processing.stack_edit.select_frames`
      - Generate a list of frame indices to drop, keeping only the selected frames.
-     - data (ndarray, 3D), keep_indices (list of int, frames to retain)
+     - data (ndarray, 3D), keep_indices (list of int, frames to retain).
+   * - :func:`~playnano.processing.stack_edit.drop_final_frames`
+     - Generate a list of frame indices to drop, removing the last N frames.
+     - data (ndarray, 3D), n_frames_to_drop (int, number of final frames to remove, default is 1).

--- a/src/playnano/afm_stack.py
+++ b/src/playnano/afm_stack.py
@@ -261,7 +261,7 @@ class AFMImageStack:
             f"Available masks: {list(MASK_MAP)}; "
             f"built-in filters: {list(FILTER_MAP)}; "
             f"video filters: {list(VIDEO_FILTER_MAP)}; "
-            f"methods: {[m for m in dir(self) if callable(getattr(self,m))]}; "
+            f"methods: {[m for m in dir(self) if callable(getattr(self, m))]}; "
             f"plugins: {[ep.name for ep in metadata.entry_points(group='playnano.filters')]}."  # noqa
             f"video_plugins: {[ep.name for ep in metadata.entry_points(group='playnano.video_processing')]}."  # noqa
             f"stack_edit: {list(STACK_EDIT_MAP)}; "

--- a/src/playnano/processing/stack_edit.py
+++ b/src/playnano/processing/stack_edit.py
@@ -133,6 +133,39 @@ def select_frames(data: np.ndarray, keep_indices: list[int]) -> list[int]:
     return drop_indices
 
 
+@versioned_filter("0.1.0")
+def drop_final_frames(data: np.ndarray, n_frames_to_drop: int = 1) -> list[int]:
+    """
+    Generate a list of frame indices to drop from the end of the stack.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        3D array of shape (n_frames, height, width) representing the image stack.
+    n_frames_to_drop : int
+        Number of frames to drop from the end of the stack.
+
+    Returns
+    -------
+    list of int
+        List of frame indices that should be dropped. By default, this will drop
+        the last frame (n_frames_to_drop=1).
+
+    Raises
+    ------
+    ValueError
+        If `n_frames_to_drop` is negative or exceeds the number of frames.
+    """
+    if data.ndim != 3:
+        raise ValueError(f"Expected a 3D array, got {data.ndim}D.")
+
+    n_frames = data.shape[0]
+    if n_frames_to_drop < 0 or n_frames_to_drop > n_frames:
+        raise ValueError(f"Invalid number of frames to drop: {n_frames_to_drop}")
+
+    return list(range(n_frames - n_frames_to_drop, n_frames))
+
+
 def register_stack_edit_processing() -> dict[str, Callable]:
     """
     Return a dictionary of registered stack editing processing filters.
@@ -147,4 +180,5 @@ def register_stack_edit_processing() -> dict[str, Callable]:
         "drop_frames": drop_frames,
         "drop_frame_range": drop_frame_range,
         "select_frames": select_frames,
+        "drop_final_frames": drop_final_frames,
     }

--- a/tests/test_stack_edit.py
+++ b/tests/test_stack_edit.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from playnano.processing.stack_edit import (
+    drop_final_frames,
     drop_frame_range,
     drop_frames,
     register_stack_edit_processing,
@@ -125,6 +126,36 @@ def test_select_frames_negative_index(sample_stack):
 
 
 # ---------------------------------------------------------------------
+# drop_final_frames
+# ---------------------------------------------------------------------
+
+
+def test_drop_final_frames_returns_final_indices(sample_stack):
+    """Test that drop_final_frames returns the correct final indices."""
+    drop_indices = drop_final_frames(sample_stack, 2)
+    assert drop_indices == [3, 4]
+
+
+def test_drop_final_frames_invalid_input(sample_stack):
+    """Test that drop_final_frames raises ValueError for invalid input."""
+    with pytest.raises(ValueError, match="Invalid number of frames to drop"):
+        drop_final_frames(sample_stack, 6)
+
+
+def test_drop_final_frames_invalid_dimensions():
+    """Test that drop_final_frames raises ValueError for non-3D input arrays."""
+    arr = np.zeros((4, 4))
+    with pytest.raises(ValueError, match="Expected a 3D array"):
+        drop_final_frames(arr, 2)
+
+
+def test_drop_final_frames_negative_index(sample_stack):
+    """Test that drop_final_frames raises ValueError for negative indices."""
+    with pytest.raises(ValueError, match="Invalid number of frames to drop"):
+        drop_final_frames(sample_stack, -1)
+
+
+# ---------------------------------------------------------------------
 # register_stack_edit_processing
 # ---------------------------------------------------------------------
 
@@ -132,7 +163,12 @@ def test_select_frames_negative_index(sample_stack):
 def test_register_stack_edit_processing_contains_expected_keys():
     """Test that register_stack_edit_processing returns expected keys and functions."""
     registry = register_stack_edit_processing()
-    assert set(registry.keys()) == {"drop_frames", "drop_frame_range", "select_frames"}
+    assert set(registry.keys()) == {
+        "drop_frames",
+        "drop_frame_range",
+        "select_frames",
+        "drop_final_frames",
+    }
     assert registry["drop_frames"] is drop_frames
     assert registry["drop_frame_range"] is drop_frame_range
     assert registry["select_frames"] is select_frames


### PR DESCRIPTION
Introduce another stack_edit processing function (just an index list generator), 'drop_final_frames', to remove frames from the end of a stack. Added tests and update docs.