### PR TITLE
Add drop_final_frames processing step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `drop_final_frame()` function added to `stack_edit` module, this is a helper function that generates a list for `drop_frames`
+  similarly to the other funcitons in the module.
+
 ## [0.4.0.post1] - 2026-05-12
 
 ### Documentation

--- a/src/playnano/processing/stack_edit.py
+++ b/src/playnano/processing/stack_edit.py
@@ -15,6 +15,8 @@ Functions
 - drop_frame_range : Generate a list of frame indices to drop within a given range.
 - select_frames : Generate a list of frame indices to drop, keeping only the selected
   frames.
+- drop_final_frames : Generate a list of frame indices to drop from the end of the
+  stack. Default is to drop the last frame (n_frames_to_drop=1).
 """
 
 from typing import Callable
@@ -172,9 +174,9 @@ def register_stack_edit_processing() -> dict[str, Callable]:
 
     Keys are names of the operations, values are the functions themselves.
     drop_frames is the operational function takes a 3D stack (n_frames,
-    H, W) and a list of indices and returns a ndarray. drop_frame_range and
-    select_frames are helper functions that return lists of indices to drop
-    which can be passed to drop_frames.
+    H, W) and a list of indices and returns a ndarray. drop_frame_range,
+    select_frames and drop_final_frames are helper functions that return
+    lists of indices to drop which can be passed to drop_frames.
     """
     return {
         "drop_frames": drop_frames,


### PR DESCRIPTION
Creates a `drop_final_frames` processing step function in `stack_edit` module. Similarly to the other stack edit functions other than `drop_frames` this generates a list that is then fed into `drop_frames` for consistent provenance tracking. 

Docs and tests are updated.